### PR TITLE
fix: update fromPlainArgs

### DIFF
--- a/src/core/move/msgs/MsgExecute.ts
+++ b/src/core/move/msgs/MsgExecute.ts
@@ -209,7 +209,7 @@ export class MsgExecute extends JSONSerializable<
     args: any[] = [],
     abi: string
   ): MsgExecute {
-    const module: ModuleABI = JSON.parse(Buffer.from(abi, 'base64').toString());
+    const module: ModuleABI = JSON.parse(abi);
 
     const functionAbi = module.exposed_functions.find(
       exposedFunction => exposedFunction.name === function_name

--- a/src/core/move/msgs/MsgScript.ts
+++ b/src/core/move/msgs/MsgScript.ts
@@ -140,9 +140,7 @@ export class MsgScript extends JSONSerializable<
     args: any[],
     abi: string
   ): MsgScript {
-    const functionAbi: MoveFunctionABI = JSON.parse(
-      Buffer.from(abi, 'base64').toString()
-    );
+    const functionAbi: MoveFunctionABI = JSON.parse(abi);
 
     return new MsgScript(
       sender,


### PR DESCRIPTION
update `fromPlainArgs` as abi return is not base64 anymore