### PR TITLE
fix: trim address

### DIFF
--- a/src/core/bech32.ts
+++ b/src/core/bech32.ts
@@ -67,7 +67,7 @@ export namespace AccAddress {
    * @param hexAddress hex address
    */
   export function fromHex(hexAddress: string): AccAddress {
-    const hex = hexAddress.replace(/^0x0+|^0+(?!x)/, '');
+    const hex = hexAddress.replace(/^0x0+|^0x|^0+(?!x)/, '');
     // That moudule address reach here is nearly impossible
     if (hex.length <= 40) {
       return bech32.encode(


### PR DESCRIPTION
Remove zero padding before encode bech32

examples
- 0x0000000000000000000000002bf62c0bf6ff86827aceb0681b77b07d4151bc76 => 2bf62c0bf6ff86827aceb0681b77b07d4151bc76
- 0000000000000000000000002bf62c0bf6ff86827aceb0681b77b07d4151bc76 => 2bf62c0bf6ff86827aceb0681b77b07d4151bc76