### PR TITLE
Adding a function to easily import a private key

### DIFF
--- a/src/key/PrivateKey.ts
+++ b/src/key/PrivateKey.ts
@@ -1,0 +1,48 @@
+import { RawKey } from './RawKey';
+
+export const INIT_COIN_TYPE = 118;
+
+interface PrivateKeyOptions {
+    privateKey?: string;
+}
+
+/**
+ * Implements a wallet initialized with a private key.
+ */
+export class PrivateKey extends RawKey {
+    privateKey: string;
+
+    /**
+     * Creates a new signing key from a private key.
+     *
+     * ```ts
+     * import { PrivateKey } from 'initia.js';
+     *
+     * const pk = new PrivateKey({ privateKey: '...' });
+     * console.log(pk.accAddress);
+     * ```
+     *
+     * @param options
+     */
+    constructor(options: PrivateKeyOptions) {
+        if (!options || !options.privateKey) {
+            throw new Error('Private key is required');
+        }
+
+        let { privateKey } = options;
+
+        if (privateKey.startsWith('0x')) {
+            privateKey = privateKey.slice(2);
+        }
+
+        if (privateKey.length !== 64) {
+            throw new Error('Invalid private key length');
+        }
+
+        const privateKeyBuffer = Buffer.from(privateKey, 'hex');
+
+        super(privateKeyBuffer);
+
+        this.privateKey = privateKeyBuffer.toString('hex');
+    }
+}

--- a/src/key/index.ts
+++ b/src/key/index.ts
@@ -1,4 +1,5 @@
 export * from './ledger';
 export * from './Key';
 export * from './MnemonicKey';
+export * from './PrivateKey';
 export * from './RawKey';


### PR DESCRIPTION
**Added a function PrivateKey.ts to ./src/key/ that uses the RawKey function to import the private key.**
PrivateKey takes a string as an argument and turns it into an array needed by RawKey. The function also checks the private key for correctness, and can work with private keys both with and without the “0x” prefix. 

**I also made changes to index.ts to add a function to the list of available functions.**