### PR TITLE
fix price query params

### DIFF
--- a/src/client/lcd/api/OracleAPI.ts
+++ b/src/client/lcd/api/OracleAPI.ts
@@ -18,7 +18,8 @@ export class OracleAPI extends BaseAPI {
     return this.c
       .get<{ price: QuotePrice.Data }>(`/slinky/oracle/v1/get_price`, {
         ...params,
-        currency_pair_id: pair.toString(),
+        'currency_pair.Base': pair.Base,
+        'currency_pair.Quote': pair.Quote,
       })
       .then((d) => QuotePrice.fromData(d.price))
   }


### PR DESCRIPTION
- seems query param setting is incorrect. fixed params for Base and Quote
- AS-IS: https://lcd.initiation-1.initia.xyz/slinky/oracle/v1/get_price?currency_pair_id=BTC%2FUSD
- TO-BE: https://lcd.initiation-1.initia.xyz/slinky/oracle/v1/get_price?currency_pair.Base=BTC&currency_pair.Quote=USD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced the clarity of currency pair information in API calls by separating it into distinct Base and Quote properties.
	- Refined the structure of parameters to improve maintainability and future development efforts without altering overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->