### PR TITLE
Allow other operations for tx search api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@initia/initia.js",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@initia/initia.js",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@initia/initia.proto": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/initia.js",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "The JavaScript SDK for Initia",
   "license": "Apache-2.0",
   "author": "Initia Foundation",

--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -186,8 +186,14 @@ export namespace SimulateResponse {
   }
 }
 
+export type TxSearchOp = '=' | '<' | '<=' | '>' | '>=' | 'CONTAINS' | 'EXISTS'
+
 export interface TxSearchOptions extends PaginationOptions {
-  query: { key: string; value: string }[]
+  query: {
+    key: string
+    value: string
+    op?: TxSearchOp
+  }[]
 }
 
 export class TxAPI extends BaseAPI {
@@ -515,18 +521,19 @@ export class TxAPI extends BaseAPI {
   ): Promise<TxSearchResult> {
     const params = new URLSearchParams()
 
-    // build search params
-    options.query?.forEach((v) =>
-      params.append(
-        'query',
-        v.key === 'tx.height' ? `${v.key}=${v.value}` : `${v.key}='${v.value}'`
-      )
-    )
+    const query: string = (options.query ?? []).reduce((str, q) => {
+      const op = q.op ?? '='
+      const value = q.key === 'tx.height' ? `${q.value}` : `'${q.value}'`
+      const queryStr =
+        op === 'EXISTS' ? `${q.key} ${op}` : `${q.key} ${op} ${value}`
+      return str ? `${str} AND ${queryStr}` : queryStr
+    }, '')
 
+    params.append('query', query)
     delete options['query']
 
     Object.entries(options).forEach((v) => {
-      params.append(v[0], v[1] as string)
+      params.append(v[0], v[1].toString())
     })
 
     return this.c

--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -522,6 +522,7 @@ export class TxAPI extends BaseAPI {
     const params = new URLSearchParams()
 
     const query: string = (options.query ?? []).reduce((str, q) => {
+      if (!q.key) return str
       const op = q.op ?? '='
       const value = q.key === 'tx.height' ? `${q.value}` : `'${q.value}'`
       const queryStr =
@@ -530,7 +531,7 @@ export class TxAPI extends BaseAPI {
     }, '')
 
     if (query) params.append('query', query)
-    delete options['query']
+    options['query'] = undefined
 
     Object.entries(options).forEach((v) => {
       params.append(v[0], v[1].toString())

--- a/src/client/lcd/api/TxAPI.ts
+++ b/src/client/lcd/api/TxAPI.ts
@@ -529,7 +529,7 @@ export class TxAPI extends BaseAPI {
       return str ? `${str} AND ${queryStr}` : queryStr
     }, '')
 
-    params.append('query', query)
+    if (query) params.append('query', query)
     delete options['query']
 
     Object.entries(options).forEach((v) => {


### PR DESCRIPTION
```
tx.height > 1 AND tx.height < 1000 AND move.type_tag CONTAINS '0x1::fungible_asset::DepositEvent'
```

the above tx search condition can be queried as below

```
await lcd.tx.search({
  query: [
    { key: 'tx.height', value: '1', op: '>'},
    { key: 'tx.height', value: '1000', op: '<'},
    { key: 'move.type_tag', value: '0x1::fungible_asset::DepositEvent', op: 'CONTAINS' },
  ]
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced search functionality with new operators for more complex query conditions.
	- Updated query options allowing for optional specification of operators alongside keys and values.

- **Refactor**
	- Improved logic for constructing search parameters, resulting in a more efficient query string generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->