### PR TITLE
Feat/eth-pubkey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@initia/initia.js",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@initia/initia.js",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@initia/initia.proto": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/initia.js",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "The JavaScript SDK for Initia",
   "license": "Apache-2.0",
   "author": "Initia Foundation",

--- a/src/core/PublicKey.spec.ts
+++ b/src/core/PublicKey.spec.ts
@@ -1,4 +1,5 @@
 import {
+  EthPublicKey,
   LegacyAminoMultisigPublicKey,
   SimplePublicKey,
   ValConsPublicKey,
@@ -32,6 +33,15 @@ describe('PublicKey', () => {
     )
     expect(pubkey.address()).toEqual(
       'initvalcons1mlhj044zpxqdeaajfxpnav59rp4ap38tgp3hzm'
+    )
+  })
+
+  it('EthPubkey address', () => {
+    const pubkey = new EthPublicKey(
+      'Ahng0jM7JGSIWF38ey+qwH7T5EcUvzQqued27hn5kSgl'
+    )
+    expect(pubkey.address()).toEqual(
+      'init18cuwmw9f423hgfl9k8d6an8p6ffvvghvtmu6l7'
     )
   })
 })

--- a/src/core/PublicKey.ts
+++ b/src/core/PublicKey.ts
@@ -15,10 +15,6 @@ const pubkeyAminoPrefixSecp256k1 = Buffer.from(
   'eb5ae987' + '21' /* fixed length */,
   'hex'
 )
-const pubkeyAminoPrefixEd25519 = Buffer.from(
-  '1624de64' + '20' /* fixed length */,
-  'hex'
-)
 /** See https://github.com/tendermint/tendermint/commit/38b401657e4ad7a7eeb3c30a3cbf512037df3740 */
 const pubkeyAminoPrefixMultisigThreshold = Buffer.from(
   '22c1f7e2' /* variable length not included */,
@@ -163,10 +159,6 @@ export class SimplePublicKey extends JSONSerializable<
   public address(): string {
     return bech32.encode('init', bech32.toWords(this.rawAddress()))
   }
-
-  public pubkeyAddress(): string {
-    return bech32.encode('initpub', bech32.toWords(this.encodeAminoPubkey()))
-  }
 }
 
 export namespace SimplePublicKey {
@@ -215,10 +207,6 @@ export class LegacyAminoMultisigPublicKey extends JSONSerializable<
 
   public address(): string {
     return bech32.encode('init', bech32.toWords(this.rawAddress()))
-  }
-
-  public pubkeyAddress(): string {
-    return bech32.encode('initpub', bech32.toWords(this.encodeAminoPubkey()))
   }
 
   public static fromAmino(
@@ -359,13 +347,6 @@ export class ValConsPublicKey extends JSONSerializable<
     return ValConsPublicKey.fromProto(ValConsPubKey_pb.decode(pubkeyAny.value))
   }
 
-  public encodeAminoPubkey(): Uint8Array {
-    return Buffer.concat([
-      pubkeyAminoPrefixEd25519,
-      Buffer.from(this.key, 'base64'),
-    ])
-  }
-
   public rawAddress(): Uint8Array {
     const pubkeyData = Buffer.from(this.key, 'base64')
     return sha256(pubkeyData).slice(0, 20)
@@ -373,13 +354,6 @@ export class ValConsPublicKey extends JSONSerializable<
 
   public address(): string {
     return bech32.encode('initvalcons', bech32.toWords(this.rawAddress()))
-  }
-
-  public pubkeyAddress(): string {
-    return bech32.encode(
-      'initvalconspub',
-      bech32.toWords(this.encodeAminoPubkey())
-    )
   }
 }
 
@@ -449,16 +423,9 @@ export class EthPublicKey extends JSONSerializable<
     return EthPublicKey.fromProto(EthPubKey_pb.decode(pubkeyAny.value))
   }
 
-  // public encodeAminoPubkey(): Uint8Array {
-  //   return Buffer.concat([
-  //     pubkeyAminoPrefixSecp256k1,
-  //     Buffer.from(this.key, 'base64'),
-  //   ])
-  // }
-
   public rawAddress(): Uint8Array {
-    const pubKey = secp256k1.publicKeyVerify(Buffer.from(this.key, 'base64'))
-    if (!pubKey) {
+    const verified = secp256k1.publicKeyVerify(Buffer.from(this.key, 'base64'))
+    if (!verified) {
       throw new Error('Invalid public key')
     }
 
@@ -474,10 +441,6 @@ export class EthPublicKey extends JSONSerializable<
   public address(): string {
     return bech32.encode('init', bech32.toWords(this.rawAddress()))
   }
-
-  // public pubkeyAddress(): string {
-  //   return bech32.encode('initpub', bech32.toWords(this.encodeAminoPubkey()))
-  // }
 }
 
 export namespace EthPublicKey {

--- a/src/core/PublicKey.ts
+++ b/src/core/PublicKey.ts
@@ -457,15 +457,18 @@ export class EthPublicKey extends JSONSerializable<
   // }
 
   public rawAddress(): Uint8Array {
-    const pubKey = secp256k1.publicKeyVerify(Buffer.from(this.key, 'base64'));
+    const pubKey = secp256k1.publicKeyVerify(Buffer.from(this.key, 'base64'))
     if (!pubKey) {
-      throw new Error('Invalid public key');
+      throw new Error('Invalid public key')
     }
 
     // Serialize the public key in uncompressed format (65 bytes)
-    const pubBytes = secp256k1.publicKeyConvert(Buffer.from(this.key, 'base64'), false);
+    const pubBytes = secp256k1.publicKeyConvert(
+      Buffer.from(this.key, 'base64'),
+      false
+    )
 
-    return keccak256(pubBytes.slice(1)).slice(12);
+    return keccak256(pubBytes.slice(1)).slice(12)
   }
 
   public address(): string {


### PR DESCRIPTION
- add eth pubkey

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for Ethereum public keys, enhancing the existing public key framework.
	- Added a new class, `EthPublicKey`, with methods for conversion and address generation.

- **Tests**
	- Expanded test coverage for the `PublicKey` suite by adding a test case for the `EthPublicKey` class.

- **Chores**
	- Updated version number from 0.2.17 to 0.2.18 in the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->