### PR TITLE
Add eth option for mnemonic and raw key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@initia/initia.js",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@initia/initia.js",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@initia/initia.proto": "^0.2.3",
@@ -9655,9 +9655,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "dev": true
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/initia.js",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "The JavaScript SDK for Initia",
   "license": "Apache-2.0",
   "author": "Initia Foundation",

--- a/src/key/MnemonicKey.ts
+++ b/src/key/MnemonicKey.ts
@@ -24,12 +24,18 @@ interface MnemonicKeyOptions {
    * Coin type. Default is INIT, 118.
    */
   coinType?: number
+
+  /**
+   * Whether to use eth pubkey
+   */
+  eth?: boolean
 }
 
 const DEFAULT_OPTIONS = {
   account: 0,
   index: 0,
   coinType: INIT_COIN_TYPE,
+  eth: false,
 }
 
 /**
@@ -66,7 +72,7 @@ export class MnemonicKey extends RawKey {
    * @param options
    */
   constructor(options: MnemonicKeyOptions = {}) {
-    const { account, index, coinType } = {
+    const { account, index, coinType, eth } = {
       ...DEFAULT_OPTIONS,
       ...options,
     }
@@ -84,7 +90,7 @@ export class MnemonicKey extends RawKey {
       throw new Error('Failed to derive key pair')
     }
 
-    super(privateKey)
+    super(privateKey, eth)
     this.mnemonic = mnemonic
   }
 }

--- a/src/key/RawKey.ts
+++ b/src/key/RawKey.ts
@@ -1,7 +1,7 @@
 import { SHA256, Word32Array } from 'jscrypto'
 import * as secp256k1 from 'secp256k1'
 import { Key } from './Key'
-import { SimplePublicKey } from '../core'
+import { EthPublicKey, SimplePublicKey } from '../core'
 import keccak256 from 'keccak256'
 
 /**
@@ -13,12 +13,18 @@ export class RawKey extends Key {
    */
   public privateKey: Buffer
 
-  constructor(privateKey: Buffer) {
+  constructor(privateKey: Buffer, eth = false) {
     const publicKey = secp256k1.publicKeyCreate(
       new Uint8Array(privateKey),
       true
     )
-    super(new SimplePublicKey(Buffer.from(publicKey).toString('base64')))
+
+    if (eth) {
+      super(new EthPublicKey(Buffer.from(publicKey).toString('base64')))
+    } else {
+      super(new SimplePublicKey(Buffer.from(publicKey).toString('base64')))
+    }
+
     this.privateKey = privateKey
   }
 

--- a/src/key/RawKey.ts
+++ b/src/key/RawKey.ts
@@ -13,7 +13,10 @@ export class RawKey extends Key {
    */
   public privateKey: Buffer
 
-  constructor(privateKey: Buffer, eth = false) {
+  constructor(
+    privateKey: Buffer,
+    public eth = false
+  ) {
     const publicKey = secp256k1.publicKeyCreate(
       new Uint8Array(privateKey),
       true
@@ -36,6 +39,8 @@ export class RawKey extends Key {
 
   // eslint-disable-next-line @typescript-eslint/require-await
   public async sign(payload: Buffer): Promise<Buffer> {
+    if (this.eth) return this.signWithKeccak256(payload)
+
     const hash = Buffer.from(
       SHA256.hash(new Word32Array(payload)).toString(),
       'hex'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for Ethereum public keys in the `MnemonicKey` and `RawKey` classes.
	- Users can now specify whether to use an Ethereum public key through a new optional parameter.

- **Bug Fixes**
	- Updated version number in `package.json` to reflect the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->