### PR TITLE
Typos Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import { MnemonicKey } from '@initia/initia.js'
 const key = new MnemonicKey({
     mnemonic: 'bird upset ...  evil cigar', // (optional) if null, generate a new Mnemonic key
     account: 0, // (optional) BIP44 account number. default = 0
-    index: 0, // (optional) BIP44 index number. defualt = 0
+    index: 0, // (optional) BIP44 index number. default = 0
     coinType: 118, // (optional) BIP44 coinType. default = 118
 })
 ```
@@ -111,7 +111,7 @@ import { MsgDelegate } from '@initia/initia.js'
 
 const msg = new MsgDelegate(
     'init1kdwzpz3wzvpdj90gtga4fw5zm9tk4cyrgnjauu', // delegator address
-    'init18sj3x80fdjc6gzfvwl7lf8sxcvuvqjpvcmp6np', // validator's operator addres
+    'init18sj3x80fdjc6gzfvwl7lf8sxcvuvqjpvcmp6np', // validator's operator address
     '100000uinit',                                 // delegate amount
 )
 ```
@@ -125,7 +125,7 @@ import { MsgUndelegate } from '@initia/initia.js'
 
 const msg = new MsgUndelegate(
     'init1kdwzpz3wzvpdj90gtga4fw5zm9tk4cyrgnjauu', // delegator address
-    'init18sj3x80fdjc6gzfvwl7lf8sxcvuvqjpvcmp6np', // validator's operator addres
+    'init18sj3x80fdjc6gzfvwl7lf8sxcvuvqjpvcmp6np', // validator's operator address
     '100000uinit',                                 // undelegate amount
 )
 ```


### PR DESCRIPTION
### Added typo corrections to documentation

**In the Key section**

"defualt" should be corrected to "**default**".

**In the MsgDelegate() section**

"validator's operator addres" should be corrected to "validator's operator **address**".

**In the MsgUndelegate() section**

"validator's operator addres" should be corrected to "validator's operator **address**" (same as above).

**Corrected.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected typographical errors for improved clarity in the README, including terms related to the `MnemonicKey`, `MsgDelegate`, and `MsgUndelegate` sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->