### PR TITLE
Fix computeEndpoint method

### DIFF
--- a/src/client/rest/APIRequester.spec.ts
+++ b/src/client/rest/APIRequester.spec.ts
@@ -54,4 +54,19 @@ describe('APIRequester', () => {
       }
     )
   })
+  
+  it('handles baseURL with path and endpoint without leading slash', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: null });
+
+    const request = new APIRequester('https://rest.testnet.initia.xyz/bar');
+    await request.get('foo');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://rest.testnet.initia.xyz/foo',
+      {
+        headers: new axios.AxiosHeaders(),
+        params: {},
+      }
+    );
+  });
 })

--- a/src/client/rest/APIRequester.spec.ts
+++ b/src/client/rest/APIRequester.spec.ts
@@ -62,7 +62,7 @@ describe('APIRequester', () => {
     await request.get('foo');
 
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      'https://rest.testnet.initia.xyz/foo',
+      'https://rest.testnet.initia.xyz/bar/foo',
       {
         headers: new axios.AxiosHeaders(),
         params: {},

--- a/src/client/rest/APIRequester.ts
+++ b/src/client/rest/APIRequester.ts
@@ -52,13 +52,15 @@ export class APIRequester {
   }
 
   private computeEndpoint(endpoint: string) {
-    const url = new URL(this.baseURL)
+	  const relativeEndpoint = endpoint.replace(/^\/+/, '');
+	  const baseURLObject = new URL(this.baseURL);
 
-    url.pathname === '/'
-      ? (url.pathname = endpoint)
-      : (url.pathname += endpoint)
+	  if (!baseURLObject.pathname.endsWith('/')) {
+      baseURLObject.pathname += '/';
+    }
+    baseURLObject.pathname += relativeEndpoint;
 
-    return url.toString()
+    return baseURLObject.toString();
   }
 
   public async getRaw<T>(

--- a/src/client/rest/APIRequester.ts
+++ b/src/client/rest/APIRequester.ts
@@ -52,10 +52,10 @@ export class APIRequester {
   }
 
   private computeEndpoint(endpoint: string) {
-	  const relativeEndpoint = endpoint.replace(/^\/+/, '');
-	  const baseURLObject = new URL(this.baseURL);
+    const relativeEndpoint = endpoint.replace(/^\/+/, '');
+    const baseURLObject = new URL(this.baseURL);
 
-	  if (!baseURLObject.pathname.endsWith('/')) {
+    if (!baseURLObject.pathname.endsWith('/')) {
       baseURLObject.pathname += '/';
     }
     baseURLObject.pathname += relativeEndpoint;


### PR DESCRIPTION
## Summary

This pull request fixes an issue in the `computeEndpoint` method where if `baseURL` contains a path and `endpoint` does not start with a leading slash, it was forming URLs incorrectly.

## Changes

- **computeEndpoint method modified:** Checks that when `baseURL` has a path (e.g., `/api`) and `endpoint` lacks a leading slash (e.g., `users`), the resulting URL correctly includes a slash between them.

## Test Results

**Before Fix:**

- Base URL `https://example.com/api` and endpoint `users` resulted in `https://example.com/apiusers` .

**After Fix:**

- Now correctly results in `https://example.com/api/users` .

## Explanation

- What the bug was: When `baseURL` and `endpoint` were being combined, if neither had appropriate slashes and the baseURL had a path, the concatenation would not contain a slash, making incorrect URLs.
- How the fix works: Now, the `computeEndpoint` method will add a forward slash if necessary.

## Tests

- Added another test to [src/client/rest/APIRequester.spec.ts](https://github.com/shak58/initia.js/blob/84c5001d9a613d3c90c2d0e041a31cdf1b7fad96/src/client/rest/APIRequester.spec.ts#L58)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced URL construction in the APIRequester to ensure correct handling of endpoints without leading slashes.

- **Tests**
	- Introduced a new test case to validate the APIRequester’s behavior with a base URL and an endpoint lacking a leading slash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->