### PR TITLE
Fetch gas prices from chain if empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@initia/initia.js",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@initia/initia.js",
-      "version": "0.2.31",
+      "version": "0.2.32",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/initia.js",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "description": "The JavaScript SDK for Initia",
   "license": "Apache-2.0",
   "author": "Initia Foundation",

--- a/src/client/rest/RESTClient.ts
+++ b/src/client/rest/RESTClient.ts
@@ -166,7 +166,7 @@ export class RESTClient {
   public async gasPrices(): Promise<Coins.Input | undefined> {
     try {
       const opchildParams = await this.opchild.parameters()
-      return opchildParams.min_gas_prices.toString() || '0uinit'
+      return opchildParams.min_gas_prices.toArray()[0]?.toString() ?? '0uinit'
     } catch {
       try {
         const moveParams = await this.move.parameters()

--- a/src/client/rest/RESTClient.ts
+++ b/src/client/rest/RESTClient.ts
@@ -32,7 +32,7 @@ import {
   WasmAPI,
 } from './api'
 import { Wallet } from './Wallet'
-import { Coins } from '../../core'
+import { Coin, Coins } from '../../core'
 import { Key } from '../../key'
 
 export interface RESTClientConfig {
@@ -54,12 +54,6 @@ export interface RESTClientConfig {
 
 const DEFAULT_REST_OPTIONS: Partial<RESTClientConfig> = {
   gasAdjustment: '1.75',
-}
-
-const DEFAULT_GAS_PRICES_BY_CHAIN_ID: Record<string, Coins.Input> = {
-  default: {
-    uinit: 0.15,
-  },
 }
 
 /**
@@ -125,9 +119,6 @@ export class RESTClient {
     this.URL = URL
     this.config = {
       ...DEFAULT_REST_OPTIONS,
-      gasPrices:
-        (config?.chainId && DEFAULT_GAS_PRICES_BY_CHAIN_ID[config.chainId]) ??
-        DEFAULT_GAS_PRICES_BY_CHAIN_ID['default'],
       ...config,
     }
     this.apiRequester = apiRequester ?? new APIRequester(this.URL)
@@ -170,6 +161,23 @@ export class RESTClient {
    */
   public wallet(key: Key): Wallet {
     return new Wallet(this, key)
+  }
+
+  public async gasPrices(): Promise<Coins.Input | undefined> {
+    try {
+      const opchildParams = await this.opchild.parameters()
+      return opchildParams.min_gas_prices.toString() || '0uinit'
+    } catch {
+      try {
+        const moveParams = await this.move.parameters()
+        return new Coin(
+          moveParams.base_denom,
+          moveParams.base_min_gas_price
+        ).toString()
+      } catch {
+        return undefined
+      }
+    }
   }
 }
 

--- a/src/client/rest/api/TxAPI.ts
+++ b/src/client/rest/api/TxAPI.ts
@@ -299,6 +299,10 @@ export class TxAPI extends BaseAPI {
     signers: SignerData[],
     options: CreateTxOptions
   ): Promise<Fee> {
+    if (!this.rest.config.gasPrices) {
+      this.rest.config.gasPrices = await this.rest.gasPrices()
+    }
+
     const gasPrices = options.gasPrices ?? this.rest.config.gasPrices
     const gasAdjustment =
       options.gasAdjustment ?? this.rest.config.gasAdjustment


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method for asynchronously retrieving gas prices, enhancing dynamic fee estimation.
  - Updated fee estimation logic to ensure gas prices are fetched and applied when not preconfigured.

- **Chores**
  - Updated the package version from "0.2.31" to "0.2.32".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->