### PR TITLE
Change default coin type to 60 and set eth pubkey as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const key = new MnemonicKey({
     mnemonic: 'bird upset ...  evil cigar', // (optional) if null, generate a new Mnemonic key
     account: 0, // (optional) BIP44 account number. default = 0
     index: 0, // (optional) BIP44 index number. default = 0
-    coinType: 118, // (optional) BIP44 coinType. default = 118
+    coinType: 60, // (optional) BIP44 coinType. default = 60
 })
 ```
 

--- a/src/key/MnemonicKey.ts
+++ b/src/key/MnemonicKey.ts
@@ -4,7 +4,7 @@ import { generateMnemonic, mnemonicToSeedSync } from 'bip39'
 import { RawKey } from './RawKey'
 
 const bip32 = BIP32Factory(ecc)
-export const INIT_COIN_TYPE = 118
+export const INIT_COIN_TYPE = 60
 
 interface MnemonicKeyOptions {
   /**
@@ -23,7 +23,7 @@ interface MnemonicKeyOptions {
   index?: number
 
   /**
-   * Coin type. Default is INIT, 118.
+   * Coin type. Default is INIT, 60.
    */
   coinType?: number
 
@@ -37,7 +37,7 @@ const DEFAULT_OPTIONS = {
   account: 0,
   index: 0,
   coinType: INIT_COIN_TYPE,
-  eth: false,
+  eth: true,
 }
 
 /**

--- a/src/key/RawKey.ts
+++ b/src/key/RawKey.ts
@@ -17,7 +17,7 @@ export class RawKey extends Key {
    */
   public eth: boolean
 
-  constructor(privateKey: Buffer, eth = false) {
+  constructor(privateKey: Buffer, eth = true) {
     const publicKey = secp256k1.publicKeyCreate(
       new Uint8Array(privateKey),
       true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated mnemonic key generation to use coin type 60, enhancing compatibility with current blockchain networks.
	- Enabled Ethereum public key support by default during key creation to streamline Ethereum integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->