### PR TITLE
Rename ESM build to .mjs and comment out problematic deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "url": "https://github.com/initia-labs/initia.js"
   },
   "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "import": "./dist/index.mjs"
     }
   },
   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,24 +7,20 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
-      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'),
+      fileName: (format) => (format === 'es' ? 'index.mjs' : 'index.cjs'),
       formats: ['es', 'cjs'],
     },
     rollupOptions: {
       external: [
-        new RegExp('^@initia/.*'),
         new RegExp('^@ledgerhq/.*'),
-        new RegExp('^jscrypto.*'),
         '@bitcoinerlab/secp256k1',
         '@mysten/bcs',
         'axios',
         'bech32',
-        'bignumber.js',
         'bip32',
         'bip39',
         'keccak256',
         'ripemd160',
-        'secp256k1',
         'semver',
         'ws',
       ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The SDK now offers native ES module support (.mjs) for improved compatibility while still maintaining CommonJS support.
  
- **Chores**
  - Refined build settings to update output naming conventions and streamline external dependency handling for a more optimized distribution setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->