### PR TITLE
feat: add missing channel upgrade open msg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@initia/initia.js",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@initia/initia.js",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/initia.js",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "The JavaScript SDK for Initia",
   "license": "Apache-2.0",
   "author": "Initia Foundation",

--- a/src/core/Msg.ts
+++ b/src/core/Msg.ts
@@ -112,6 +112,7 @@ import {
   MsgChannelUpgradeConfirm,
   MsgChannelUpgradeTimeout,
   MsgChannelUpgradeCancel,
+  MsgChannelUpgradeOpen,
 } from './ibc/core/channel/msgs'
 import {
   IbcClientMsg,
@@ -953,6 +954,8 @@ export namespace Msg {
         return MsgChannelUpgradeTimeout.fromData(data)
       case '/ibc.core.channel.v1.MsgChannelUpgradeCancel':
         return MsgChannelUpgradeCancel.fromData(data)
+      case '/ibc.core.channel.v1.MsgChannelUpgradeOpen':
+        return MsgChannelUpgradeOpen.fromData(data)
 
       // ibc-client
       case '/ibc.core.client.v1.MsgCreateClient':
@@ -1393,6 +1396,8 @@ export namespace Msg {
         return MsgChannelUpgradeTimeout.unpackAny(proto)
       case '/ibc.core.channel.v1.MsgChannelUpgradeCancel':
         return MsgChannelUpgradeCancel.unpackAny(proto)
+      case '/ibc.core.channel.v1.MsgChannelUpgradeOpen':
+        return MsgChannelUpgradeOpen.unpackAny(proto)
 
       // ibc-client
       case '/ibc.core.client.v1.MsgCreateClient':

--- a/src/core/ibc/core/channel/Channel.ts
+++ b/src/core/ibc/core/channel/Channel.ts
@@ -1,9 +1,13 @@
-import {
-  State,
-  Order,
-  Channel as Channel_pb,
-} from '@initia/initia.proto/ibc/core/channel/v1/channel'
 import { JSONSerializable } from '../../../../util/json'
+import {
+  Channel as Channel_pb,
+  stateFromJSON,
+  stateToJSON,
+  orderFromJSON,
+  orderToJSON,
+} from '@initia/initia.proto/ibc/core/channel/v1/channel'
+import { ChannelState } from './ChannelState'
+import { ChannelOrder } from './ChannelOrder'
 import { ChannelCounterparty } from './ChannelCounterparty'
 
 /**
@@ -25,8 +29,8 @@ export class Channel extends JSONSerializable<
    * @param upgrade_sequence the latest upgrade attempt performed by this channel; 0 indicates the channel has never been upgraded
    */
   constructor(
-    public state: State,
-    public ordering: Order,
+    public state: ChannelState,
+    public ordering: ChannelOrder,
     public counterparty: ChannelCounterparty | undefined,
     public connection_hops: string[],
     public version: string,
@@ -45,8 +49,8 @@ export class Channel extends JSONSerializable<
       upgrade_sequence,
     } = data
     return new Channel(
-      state,
-      ordering,
+      stateFromJSON(state),
+      orderFromJSON(ordering),
       counterparty ? ChannelCounterparty.fromAmino(counterparty) : undefined,
       connection_hops,
       version,
@@ -64,8 +68,8 @@ export class Channel extends JSONSerializable<
       upgrade_sequence,
     } = this
     return {
-      state,
-      ordering,
+      state: stateToJSON(state),
+      ordering: orderToJSON(ordering),
       counterparty: counterparty?.toAmino(),
       connection_hops,
       version,
@@ -83,8 +87,8 @@ export class Channel extends JSONSerializable<
       upgrade_sequence,
     } = data
     return new Channel(
-      state,
-      ordering,
+      stateFromJSON(state),
+      orderFromJSON(ordering),
       counterparty ? ChannelCounterparty.fromData(counterparty) : undefined,
       connection_hops,
       version,
@@ -102,8 +106,8 @@ export class Channel extends JSONSerializable<
       upgrade_sequence,
     } = this
     return {
-      state,
-      ordering,
+      state: stateToJSON(state),
+      ordering: orderToJSON(ordering),
       counterparty: counterparty?.toData(),
       connection_hops,
       version,
@@ -146,8 +150,8 @@ export class Channel extends JSONSerializable<
 
 export namespace Channel {
   export interface Amino {
-    state: State
-    ordering: Order
+    state: string
+    ordering: string
     counterparty?: ChannelCounterparty.Amino
     connection_hops: string[]
     version: string
@@ -155,8 +159,8 @@ export namespace Channel {
   }
 
   export interface Data {
-    state: State
-    ordering: Order
+    state: string
+    ordering: string
     counterparty?: ChannelCounterparty.Data
     connection_hops: string[]
     version: string

--- a/src/core/ibc/core/channel/IdentifiedChannel.ts
+++ b/src/core/ibc/core/channel/IdentifiedChannel.ts
@@ -1,9 +1,13 @@
-import {
-  State,
-  Order,
-  IdentifiedChannel as IdentifiedChannel_pb,
-} from '@initia/initia.proto/ibc/core/channel/v1/channel'
 import { JSONSerializable } from '../../../../util/json'
+import {
+  IdentifiedChannel as IdentifiedChannel_pb,
+  stateFromJSON,
+  stateToJSON,
+  orderFromJSON,
+  orderToJSON,
+} from '@initia/initia.proto/ibc/core/channel/v1/channel'
+import { ChannelState } from './ChannelState'
+import { ChannelOrder } from './ChannelOrder'
 import { ChannelCounterparty } from './ChannelCounterparty'
 
 /**
@@ -25,8 +29,8 @@ export class IdentifiedChannel extends JSONSerializable<
    * @param upgrade_sequence the latest upgrade attempt performed by this channel; 0 indicates the channel has never been upgraded
    */
   constructor(
-    public state: State,
-    public ordering: Order,
+    public state: ChannelState,
+    public ordering: ChannelOrder,
     public counterparty: ChannelCounterparty | undefined,
     public connection_hops: string[],
     public version: string,
@@ -49,8 +53,8 @@ export class IdentifiedChannel extends JSONSerializable<
       upgrade_sequence,
     } = data
     return new IdentifiedChannel(
-      state,
-      ordering,
+      stateFromJSON(state),
+      orderFromJSON(ordering),
       counterparty ? ChannelCounterparty.fromAmino(counterparty) : undefined,
       connection_hops,
       version,
@@ -72,8 +76,8 @@ export class IdentifiedChannel extends JSONSerializable<
       upgrade_sequence,
     } = this
     return {
-      state,
-      ordering,
+      state: stateToJSON(state),
+      ordering: orderToJSON(ordering),
       counterparty: counterparty?.toAmino(),
       connection_hops,
       version,
@@ -95,8 +99,8 @@ export class IdentifiedChannel extends JSONSerializable<
       upgrade_sequence,
     } = data
     return new IdentifiedChannel(
-      state,
-      ordering,
+      stateFromJSON(state),
+      orderFromJSON(ordering),
       counterparty ? ChannelCounterparty.fromData(counterparty) : undefined,
       connection_hops,
       version,
@@ -118,8 +122,8 @@ export class IdentifiedChannel extends JSONSerializable<
       upgrade_sequence,
     } = this
     return {
-      state,
-      ordering,
+      state: stateToJSON(state),
+      ordering: orderToJSON(ordering),
       counterparty: counterparty?.toData(),
       connection_hops,
       version,
@@ -170,8 +174,8 @@ export class IdentifiedChannel extends JSONSerializable<
 
 export namespace IdentifiedChannel {
   export interface Amino {
-    state: State
-    ordering: Order
+    state: string
+    ordering: string
     counterparty?: ChannelCounterparty.Amino
     connection_hops: string[]
     version: string
@@ -181,8 +185,8 @@ export namespace IdentifiedChannel {
   }
 
   export interface Data {
-    state: State
-    ordering: Order
+    state: string
+    ordering: string
     counterparty?: ChannelCounterparty.Data
     connection_hops: string[]
     version: string

--- a/src/core/ibc/core/channel/msgs/MsgChannelUpgradeOpen.ts
+++ b/src/core/ibc/core/channel/msgs/MsgChannelUpgradeOpen.ts
@@ -1,0 +1,147 @@
+import { JSONSerializable } from '../../../../../util/json'
+import { AccAddress } from '../../../../bech32'
+import { Any } from '@initia/initia.proto/google/protobuf/any'
+import { MsgChannelUpgradeOpen as MsgChannelUpgradeOpen_pb } from '@initia/initia.proto/ibc/core/channel/v1/tx'
+import { Height } from '../../client/Height'
+
+/**
+ * MsgChannelUpgradeOpen defines an sdk.Msg to open a channel after a successful upgrade.
+ */
+export class MsgChannelUpgradeOpen extends JSONSerializable<
+  any,
+  MsgChannelUpgradeOpen.Data,
+  MsgChannelUpgradeOpen.Proto
+> {
+  /**
+   * @param port_id identifier of the port to use
+   * @param channel_id identifier of the channel to open after upgrade
+   * @param counterparty_channel_state the state of the counterparty channel
+   * @param counterparty_upgrade_sequence the upgrade sequence from the counterparty
+   * @param proof_channel proof of the channel state
+   * @param proof_height height at which the proof was retrieved
+   * @param signer signer address
+   */
+  constructor(
+    public port_id: string,
+    public channel_id: string,
+    public counterparty_channel_state: number,
+    public counterparty_upgrade_sequence: number,
+    public proof_channel: string,
+    public proof_height: Height | undefined,
+    public signer: AccAddress
+  ) {
+    super()
+  }
+
+  public static fromAmino(_: any): MsgChannelUpgradeOpen {
+    throw new Error('Amino not supported')
+  }
+
+  public toAmino(): any {
+    throw new Error('Amino not supported')
+  }
+
+  public static fromData(data: MsgChannelUpgradeOpen.Data): MsgChannelUpgradeOpen {
+    const { 
+      port_id, 
+      channel_id, 
+      counterparty_channel_state, 
+      counterparty_upgrade_sequence, 
+      proof_channel, 
+      proof_height, 
+      signer 
+    } = data
+    return new MsgChannelUpgradeOpen(
+      port_id,
+      channel_id,
+      counterparty_channel_state,
+      Number(counterparty_upgrade_sequence),
+      proof_channel,
+      proof_height ? Height.fromData(proof_height) : undefined,
+      signer
+    )
+  }
+
+  public toData(): MsgChannelUpgradeOpen.Data {
+    const { 
+      port_id, 
+      channel_id, 
+      counterparty_channel_state, 
+      counterparty_upgrade_sequence, 
+      proof_channel, 
+      proof_height, 
+      signer 
+    } = this
+    return {
+      '@type': '/ibc.core.channel.v1.MsgChannelUpgradeOpen',
+      port_id,
+      channel_id,
+      counterparty_channel_state,
+      counterparty_upgrade_sequence: counterparty_upgrade_sequence.toString(),
+      proof_channel: Buffer.from(proof_channel).toString('base64'),
+      proof_height: proof_height?.toData(),
+      signer,
+    }
+  }
+
+  public static fromProto(proto: MsgChannelUpgradeOpen.Proto): MsgChannelUpgradeOpen {
+    return new MsgChannelUpgradeOpen(
+      proto.portId,
+      proto.channelId,
+      proto.counterpartyChannelState,
+      Number(proto.counterpartyUpgradeSequence),
+      Buffer.from(proto.proofChannel).toString('base64'),
+      proto.proofHeight ? Height.fromProto(proto.proofHeight) : undefined,
+      proto.signer
+    )
+  }
+
+  public toProto(): MsgChannelUpgradeOpen.Proto {
+    const { 
+      port_id, 
+      channel_id, 
+      counterparty_channel_state, 
+      counterparty_upgrade_sequence, 
+      proof_channel, 
+      proof_height, 
+      signer 
+    } = this
+    return MsgChannelUpgradeOpen_pb.fromPartial({
+      portId: port_id,
+      channelId: channel_id,
+      counterpartyChannelState: counterparty_channel_state,
+      counterpartyUpgradeSequence: BigInt(counterparty_upgrade_sequence),
+      proofChannel: Buffer.from(proof_channel, 'base64'),
+      proofHeight: proof_height?.toProto(),
+      signer,
+    })
+  }
+
+  public packAny(): Any {
+    return Any.fromPartial({
+      typeUrl: '/ibc.core.channel.v1.MsgChannelUpgradeOpen',
+      value: MsgChannelUpgradeOpen_pb.encode(this.toProto()).finish(),
+    })
+  }
+
+  public static unpackAny(msgAny: Any): MsgChannelUpgradeOpen {
+    return MsgChannelUpgradeOpen.fromProto(
+      MsgChannelUpgradeOpen_pb.decode(msgAny.value)
+    )
+  }
+}
+
+export namespace MsgChannelUpgradeOpen {
+  export interface Data {
+    '@type': '/ibc.core.channel.v1.MsgChannelUpgradeOpen'
+    port_id: string
+    channel_id: string
+    counterparty_channel_state: number
+    counterparty_upgrade_sequence: string
+    proof_channel: string
+    proof_height?: Height.Data
+    signer: AccAddress
+  }
+
+  export type Proto = MsgChannelUpgradeOpen_pb
+}

--- a/src/core/ibc/core/channel/msgs/MsgChannelUpgradeOpen.ts
+++ b/src/core/ibc/core/channel/msgs/MsgChannelUpgradeOpen.ts
@@ -1,7 +1,12 @@
 import { JSONSerializable } from '../../../../../util/json'
 import { AccAddress } from '../../../../bech32'
 import { Any } from '@initia/initia.proto/google/protobuf/any'
+import {
+  stateFromJSON,
+  stateToJSON,
+} from '@initia/initia.proto/ibc/core/channel/v1/channel'
 import { MsgChannelUpgradeOpen as MsgChannelUpgradeOpen_pb } from '@initia/initia.proto/ibc/core/channel/v1/tx'
+import { ChannelState } from '../ChannelState'
 import { Height } from '../../client/Height'
 
 /**
@@ -24,7 +29,7 @@ export class MsgChannelUpgradeOpen extends JSONSerializable<
   constructor(
     public port_id: string,
     public channel_id: string,
-    public counterparty_channel_state: number,
+    public counterparty_channel_state: ChannelState,
     public counterparty_upgrade_sequence: number,
     public proof_channel: string,
     public proof_height: Height | undefined,
@@ -56,7 +61,7 @@ export class MsgChannelUpgradeOpen extends JSONSerializable<
     return new MsgChannelUpgradeOpen(
       port_id,
       channel_id,
-      counterparty_channel_state,
+      stateFromJSON(counterparty_channel_state),
       Number(counterparty_upgrade_sequence),
       proof_channel,
       proof_height ? Height.fromData(proof_height) : undefined,
@@ -78,9 +83,9 @@ export class MsgChannelUpgradeOpen extends JSONSerializable<
       '@type': '/ibc.core.channel.v1.MsgChannelUpgradeOpen',
       port_id,
       channel_id,
-      counterparty_channel_state,
-      counterparty_upgrade_sequence: counterparty_upgrade_sequence.toString(),
-      proof_channel: Buffer.from(proof_channel).toString('base64'),
+      counterparty_channel_state: stateToJSON(counterparty_channel_state),
+      counterparty_upgrade_sequence: counterparty_upgrade_sequence.toFixed(),
+      proof_channel,
       proof_height: proof_height?.toData(),
       signer,
     }
@@ -140,7 +145,7 @@ export namespace MsgChannelUpgradeOpen {
     '@type': '/ibc.core.channel.v1.MsgChannelUpgradeOpen'
     port_id: string
     channel_id: string
-    counterparty_channel_state: number
+    counterparty_channel_state: string
     counterparty_upgrade_sequence: string
     proof_channel: string
     proof_height?: Height.Data

--- a/src/core/ibc/core/channel/msgs/MsgChannelUpgradeOpen.ts
+++ b/src/core/ibc/core/channel/msgs/MsgChannelUpgradeOpen.ts
@@ -41,15 +41,17 @@ export class MsgChannelUpgradeOpen extends JSONSerializable<
     throw new Error('Amino not supported')
   }
 
-  public static fromData(data: MsgChannelUpgradeOpen.Data): MsgChannelUpgradeOpen {
-    const { 
-      port_id, 
-      channel_id, 
-      counterparty_channel_state, 
-      counterparty_upgrade_sequence, 
-      proof_channel, 
-      proof_height, 
-      signer 
+  public static fromData(
+    data: MsgChannelUpgradeOpen.Data
+  ): MsgChannelUpgradeOpen {
+    const {
+      port_id,
+      channel_id,
+      counterparty_channel_state,
+      counterparty_upgrade_sequence,
+      proof_channel,
+      proof_height,
+      signer,
     } = data
     return new MsgChannelUpgradeOpen(
       port_id,
@@ -63,14 +65,14 @@ export class MsgChannelUpgradeOpen extends JSONSerializable<
   }
 
   public toData(): MsgChannelUpgradeOpen.Data {
-    const { 
-      port_id, 
-      channel_id, 
-      counterparty_channel_state, 
-      counterparty_upgrade_sequence, 
-      proof_channel, 
-      proof_height, 
-      signer 
+    const {
+      port_id,
+      channel_id,
+      counterparty_channel_state,
+      counterparty_upgrade_sequence,
+      proof_channel,
+      proof_height,
+      signer,
     } = this
     return {
       '@type': '/ibc.core.channel.v1.MsgChannelUpgradeOpen',
@@ -84,7 +86,9 @@ export class MsgChannelUpgradeOpen extends JSONSerializable<
     }
   }
 
-  public static fromProto(proto: MsgChannelUpgradeOpen.Proto): MsgChannelUpgradeOpen {
+  public static fromProto(
+    proto: MsgChannelUpgradeOpen.Proto
+  ): MsgChannelUpgradeOpen {
     return new MsgChannelUpgradeOpen(
       proto.portId,
       proto.channelId,
@@ -97,14 +101,14 @@ export class MsgChannelUpgradeOpen extends JSONSerializable<
   }
 
   public toProto(): MsgChannelUpgradeOpen.Proto {
-    const { 
-      port_id, 
-      channel_id, 
-      counterparty_channel_state, 
-      counterparty_upgrade_sequence, 
-      proof_channel, 
-      proof_height, 
-      signer 
+    const {
+      port_id,
+      channel_id,
+      counterparty_channel_state,
+      counterparty_upgrade_sequence,
+      proof_channel,
+      proof_height,
+      signer,
     } = this
     return MsgChannelUpgradeOpen_pb.fromPartial({
       portId: port_id,

--- a/src/core/ibc/core/channel/msgs/MsgChannelUpgradeTry.ts
+++ b/src/core/ibc/core/channel/msgs/MsgChannelUpgradeTry.ts
@@ -93,7 +93,7 @@ export class MsgChannelUpgradeTry extends JSONSerializable<
       channel_id,
       proposed_upgrade_connection_hops,
       counterparty_upgrade_fields: counterparty_upgrade_fields?.toData(),
-      counterparty_upgrade_sequence: counterparty_upgrade_sequence.toString(),
+      counterparty_upgrade_sequence: counterparty_upgrade_sequence.toFixed(),
       proof_channel,
       proof_upgrade,
       proof_height: proof_height?.toData(),

--- a/src/core/ibc/core/channel/msgs/index.ts
+++ b/src/core/ibc/core/channel/msgs/index.ts
@@ -15,6 +15,7 @@ import { MsgChannelUpgradeAck } from './MsgChannelUpgradeAck'
 import { MsgChannelUpgradeConfirm } from './MsgChannelUpgradeConfirm'
 import { MsgChannelUpgradeTimeout } from './MsgChannelUpgradeTimeout'
 import { MsgChannelUpgradeCancel } from './MsgChannelUpgradeCancel'
+import { MsgChannelUpgradeOpen } from './MsgChannelUpgradeOpen'
 
 export * from './MsgChannelOpenInit'
 export * from './MsgChannelOpenTry'
@@ -33,6 +34,7 @@ export * from './MsgChannelUpgradeAck'
 export * from './MsgChannelUpgradeConfirm'
 export * from './MsgChannelUpgradeTimeout'
 export * from './MsgChannelUpgradeCancel'
+export * from './MsgChannelUpgradeOpen'
 
 export type IbcChannelMsg =
   | MsgChannelOpenInit
@@ -52,6 +54,7 @@ export type IbcChannelMsg =
   | MsgChannelUpgradeConfirm
   | MsgChannelUpgradeTimeout
   | MsgChannelUpgradeCancel
+  | MsgChannelUpgradeOpen
 
 export namespace IbcChannelMsg {
   export type Data =
@@ -72,6 +75,7 @@ export namespace IbcChannelMsg {
     | MsgChannelUpgradeConfirm.Data
     | MsgChannelUpgradeTimeout.Data
     | MsgChannelUpgradeCancel.Data
+    | MsgChannelUpgradeOpen.Data
 
   export type Proto =
     | MsgChannelOpenInit.Proto
@@ -91,4 +95,5 @@ export namespace IbcChannelMsg {
     | MsgChannelUpgradeConfirm.Proto
     | MsgChannelUpgradeTimeout.Proto
     | MsgChannelUpgradeCancel.Proto
+    | MsgChannelUpgradeOpen.Proto
 }

--- a/src/core/intertx/msgs/MsgRegisterAccount.ts
+++ b/src/core/intertx/msgs/MsgRegisterAccount.ts
@@ -1,8 +1,12 @@
 import { JSONSerializable } from '../../../util/json'
 import { AccAddress } from '../../bech32'
 import { Any } from '@initia/initia.proto/google/protobuf/any'
-import { Order } from '@initia/initia.proto/ibc/core/channel/v1/channel'
+import {
+  orderFromJSON,
+  orderToJSON,
+} from '@initia/initia.proto/ibc/core/channel/v1/channel'
 import { MsgRegisterAccount as MsgRegisterAccount_pb } from '@initia/initia.proto/initia/intertx/v1/tx'
+import { ChannelOrder } from '../../ibc'
 
 export class MsgRegisterAccount extends JSONSerializable<
   MsgRegisterAccount.Amino,
@@ -19,7 +23,7 @@ export class MsgRegisterAccount extends JSONSerializable<
     public owner: AccAddress,
     public connection_id: string,
     public version: string,
-    public ordering: Order
+    public ordering: ChannelOrder
   ) {
     super()
   }
@@ -29,20 +33,30 @@ export class MsgRegisterAccount extends JSONSerializable<
       value: { owner, connection_id, version, ordering },
     } = data
 
-    return new MsgRegisterAccount(owner, connection_id, version, ordering)
+    return new MsgRegisterAccount(
+      owner,
+      connection_id,
+      version,
+      orderFromJSON(ordering)
+    )
   }
 
   public toAmino(): MsgRegisterAccount.Amino {
     const { owner, connection_id, version, ordering } = this
     return {
       type: 'intertx/MsgRegisterAccount',
-      value: { owner, connection_id, version, ordering },
+      value: { owner, connection_id, version, ordering: orderToJSON(ordering) },
     }
   }
 
   public static fromData(data: MsgRegisterAccount.Data): MsgRegisterAccount {
     const { owner, connection_id, version, ordering } = data
-    return new MsgRegisterAccount(owner, connection_id, version, ordering)
+    return new MsgRegisterAccount(
+      owner,
+      connection_id,
+      version,
+      orderFromJSON(ordering)
+    )
   }
 
   public toData(): MsgRegisterAccount.Data {
@@ -52,7 +66,7 @@ export class MsgRegisterAccount extends JSONSerializable<
       owner,
       connection_id,
       version,
-      ordering,
+      ordering: orderToJSON(ordering),
     }
   }
 
@@ -96,7 +110,7 @@ export namespace MsgRegisterAccount {
       owner: AccAddress
       connection_id: string
       version: string
-      ordering: Order
+      ordering: string
     }
   }
 
@@ -105,7 +119,7 @@ export namespace MsgRegisterAccount {
     owner: AccAddress
     connection_id: string
     version: string
-    ordering: Order
+    ordering: string
   }
 
   export type Proto = MsgRegisterAccount_pb


### PR DESCRIPTION
last time, I had missed `MsgChannelUpgradeOpen` msg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the IBC Channel Upgrade Open message (create, sign, broadcast) with JSON/Protobuf Any serialization (Amino unsupported).
* **Bug Fixes / Behavior**
  * Message decoding paths updated to recognize and process the new message across systems.
* **Changes**
  * Public JSON representations for channel state/order and related messages now use string values for enums.
  * Minor serialization formatting change for channel-upgrade-try sequence output.
* **Chores**
  * Package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->