### PR TITLE
fix: add missing upgrade field

### DIFF
--- a/src/core/ibc/core/channel/Upgrade.ts
+++ b/src/core/ibc/core/channel/Upgrade.ts
@@ -14,10 +14,12 @@ export class Upgrade extends JSONSerializable<
   /**
    * @param fields the upgrade fields
    * @param timeout the timeout for the upgrade
+   * @param next_sequence_send the next sequence send
    */
   constructor(
     public fields: UpgradeFields | undefined,
-    public timeout: Timeout | undefined
+    public timeout: Timeout | undefined,
+    public next_sequence_send: number
   ) {
     super()
   }
@@ -31,33 +33,37 @@ export class Upgrade extends JSONSerializable<
   }
 
   public static fromData(data: Upgrade.Data): Upgrade {
-    const { fields, timeout } = data
+    const { fields, timeout, next_sequence_send } = data
     return new Upgrade(
       fields ? UpgradeFields.fromData(fields) : undefined,
-      timeout ? Timeout.fromData(timeout) : undefined
+      timeout ? Timeout.fromData(timeout) : undefined,
+      parseInt(next_sequence_send)
     )
   }
 
   public toData(): Upgrade.Data {
-    const { fields, timeout } = this
+    const { fields, timeout, next_sequence_send } = this
     return {
       fields: fields?.toData(),
       timeout: timeout?.toData(),
+      next_sequence_send: next_sequence_send.toFixed(),
     }
   }
 
   public static fromProto(proto: Upgrade.Proto): Upgrade {
     return new Upgrade(
       proto.fields ? UpgradeFields.fromProto(proto.fields) : undefined,
-      proto.timeout ? Timeout.fromProto(proto.timeout) : undefined
+      proto.timeout ? Timeout.fromProto(proto.timeout) : undefined,
+      Number(proto.nextSequenceSend)
     )
   }
 
   public toProto(): Upgrade.Proto {
-    const { fields, timeout } = this
+    const { fields, timeout, next_sequence_send } = this
     return Upgrade_pb.fromPartial({
       fields: fields?.toProto(),
       timeout: timeout?.toProto(),
+      nextSequenceSend: BigInt(next_sequence_send),
     })
   }
 }
@@ -66,6 +72,7 @@ export namespace Upgrade {
   export interface Data {
     fields?: UpgradeFields.Data
     timeout?: Timeout.Data
+    next_sequence_send: string
   }
 
   export type Proto = Upgrade_pb


### PR DESCRIPTION
missed `next_sequence_send` field on `Upgrade`