### PR TITLE
feat: add table entry type and resource conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "initia.js",
-  "version": "2.0.0",
+  "name": "@initia/initia.js",
+  "version": "2.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "initia.js",
-      "version": "2.0.0",
+      "name": "@initia/initia.js",
+      "version": "2.0.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
@@ -441,7 +441,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@chain-registry/types": {
       "version": "2.0.178",
@@ -728,6 +729,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -1815,9 +1817,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1835,9 +1834,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1855,9 +1851,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1875,9 +1868,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1895,9 +1885,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1915,9 +1902,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2101,6 +2085,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2150,6 +2135,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2527,6 +2513,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3028,6 +3015,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3082,6 +3070,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4013,9 +4002,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4037,9 +4023,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4061,9 +4044,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4085,9 +4065,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4884,6 +4861,7 @@
       "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.122.0",
         "@rolldown/pluginutils": "1.0.0-rc.12"
@@ -5444,6 +5422,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5674,6 +5653,7 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5954,6 +5934,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/initia.js",
-  "version": "2.0.0-rc.0", 
+  "version": "2.0.0-rc.4", 
   "author": "Initia Foundation",
   "description": "TypeScript SDK for Initia and the interwoven ecosystem",
   "repository": "github:initia-labs/initia.js",

--- a/src/contracts/move/bcs.ts
+++ b/src/contracts/move/bcs.ts
@@ -179,9 +179,9 @@ export const bcs: typeof mystenBcs & {
  */
 export interface ParsedMoveType {
   /** Base type name (e.g., 'vector', 'u64', 'address') */
-  base: string
+  readonly base: string
   /** Type arguments for generic types */
-  typeArgs: ParsedMoveType[]
+  readonly typeArgs: readonly ParsedMoveType[]
 }
 
 /**
@@ -239,6 +239,98 @@ export function parseMoveType(typeStr: string): ParsedMoveType {
   }
 
   return { base, typeArgs }
+}
+
+/**
+ * Converts a ParsedMoveType back to its string representation.
+ * Inverse of `parseMoveType()`.
+ *
+ * @param parsed - Parsed Move type structure
+ * @returns Move type string (e.g., 'vector<u8>', '0x1::coin::Coin<T>')
+ *
+ * @example
+ * ```typescript
+ * stringifyType({ base: 'u64', typeArgs: [] })                         // 'u64'
+ * stringifyType({ base: 'vector', typeArgs: [{ base: 'u8', typeArgs: [] }] }) // 'vector<u8>'
+ * ```
+ */
+export function stringifyType(parsed: ParsedMoveType): string {
+  if (parsed.typeArgs.length === 0) return parsed.base
+  return `${parsed.base}<${parsed.typeArgs.map(stringifyType).join(', ')}>`
+}
+
+/**
+ * Resolves generic type references (T0, T1, ...) in Move type strings
+ * using the provided typeArgs array.
+ */
+export function resolveGenericTypes(types: string[], typeArgs: string[]): string[] {
+  if (typeArgs.length === 0) return types
+  return types.map(t =>
+    t.replace(/\bT(\d+)\b/g, (match, indexStr: string) => {
+      const i = parseInt(indexStr)
+      return i < typeArgs.length ? typeArgs[i] : match
+    })
+  )
+}
+
+/**
+ * Converts a JSON-parsed Move value to its JavaScript equivalent
+ * based on the Move return type from the ABI.
+ *
+ * Converts types where JSON representation differs from target:
+ * - u8/u16/u32 strings → number (defensive; chain normally returns numbers)
+ * - u64/u128/u256 strings or numbers → bigint
+ * - vector<T> → recursively converts elements
+ * - Option<T> → null or recursively converts inner value
+ *
+ * Types that are already correct (bool, address, string,
+ * Object<T>, decimal, fixed_point) pass through unchanged.
+ */
+export function convertJsonValue(value: unknown, parsed: ParsedMoveType): unknown {
+  const { base, typeArgs } = parsed
+
+  switch (base) {
+    case 'u8':
+    case 'u16':
+    case 'u32':
+      if (typeof value === 'string') return Number(value)
+      return value
+
+    case 'u64':
+    case 'u128':
+    case 'u256':
+      if (typeof value === 'string') return BigInt(value)
+      if (typeof value === 'number') return BigInt(value)
+      return value
+
+    case 'vector':
+      if (Array.isArray(value) && typeArgs.length === 1) {
+        return value.map(v => convertJsonValue(v, typeArgs[0]))
+      }
+      return value
+
+    case '0x1::option::Option':
+      if (value === null || value === undefined) return null
+      if (typeof value === 'object' && value !== null && 'vec' in value) {
+        const vec = (value as { vec: unknown[] }).vec
+        if (vec.length === 0) return null
+        if (vec.length > 1) {
+          throw new Error(
+            `Invalid Option value: vec contains ${vec.length} elements (expected 0 or 1)`
+          )
+        }
+        if (typeArgs.length === 1) {
+          return convertJsonValue(vec[0], typeArgs[0])
+        }
+      }
+      if (typeArgs.length === 1) {
+        return convertJsonValue(value, typeArgs[0])
+      }
+      return value
+
+    default:
+      return value
+  }
 }
 
 // =============================================================================

--- a/src/contracts/move/contract.ts
+++ b/src/contracts/move/contract.ts
@@ -41,9 +41,20 @@ import type {
   BuildMoveViewOptions,
 } from './types'
 import { getModuleAbi, findFunction, getNonSignerParams, type MoveQueryClient } from './abi-fetcher'
-import { encodeMoveArgs, parseMoveType, type ParsedMoveType } from './bcs'
+import {
+  encodeMoveArgs,
+  parseMoveType,
+  convertJsonValue,
+  resolveGenericTypes,
+  type ParsedMoveType,
+} from './bcs'
 import { AccAddress } from '../../util/address'
 import { jsonStringifyArg } from '../../util/json'
+import {
+  createAbiResolver,
+  convertResourceValue,
+  DEFAULT_OPAQUE_TYPES,
+} from './resource-conversion'
 
 // =============================================================================
 // Types
@@ -59,6 +70,11 @@ export interface CreateMoveContractOptions {
   useCache?: boolean
   /** Cache TTL in milliseconds (default: 5 minutes) */
   cacheTtl?: number
+  /**
+   * Additional opaque types to skip ABI resolution for (performance optimization).
+   * Must be base type strings without type arguments (e.g., `'0x1::table::Table'`).
+   */
+  opaqueTypes?: string[]
 }
 
 // =============================================================================
@@ -194,20 +210,6 @@ function hasUnresolvedGenerics(paramTypes: string[]): boolean {
   return paramTypes.some(p => /\bT\d+\b/.test(p))
 }
 
-/**
- * Resolves generic type references (T0, T1, ...) in Move type strings
- * using the provided typeArgs array.
- */
-function resolveGenericTypes(types: string[], typeArgs: string[]): string[] {
-  if (typeArgs.length === 0) return types
-  return types.map(t =>
-    t.replace(/\bT(\d+)\b/g, (match, indexStr: string) => {
-      const i = parseInt(indexStr)
-      return i < typeArgs.length ? typeArgs[i] : match
-    })
-  )
-}
-
 const KNOWN_BCS_BASES = new Set([
   'bool',
   'u8',
@@ -251,54 +253,6 @@ function allTypesResolvable(paramTypes: string[]): boolean {
 // =============================================================================
 
 /**
- * Converts a JSON-parsed view response value to a typed value
- * based on the Move return type from the ABI.
- *
- * Only converts types where JSON representation differs from target:
- * - u64/u128/u256 JSON strings → bigint
- * - vector<T> → recursively converts elements
- * - Option<T> → null or recursively converts inner value
- *
- * Types that are already correct (bool, u8/u16/u32, address, string,
- * Object<T>, decimal, fixed_point) pass through unchanged.
- */
-function convertJsonValue(value: unknown, parsed: ParsedMoveType): unknown {
-  const { base, typeArgs } = parsed
-
-  switch (base) {
-    case 'u64':
-    case 'u128':
-    case 'u256':
-      if (typeof value === 'string') return BigInt(value)
-      if (typeof value === 'number') return BigInt(value)
-      return value
-
-    case 'vector':
-      if (Array.isArray(value) && typeArgs.length === 1) {
-        return value.map(v => convertJsonValue(v, typeArgs[0]))
-      }
-      return value
-
-    case '0x1::option::Option':
-      if (value === null || value === undefined) return null
-      if (typeof value === 'object' && value !== null && 'vec' in value) {
-        const vec = (value as { vec: unknown[] }).vec
-        if (vec.length === 0) return null
-        if (vec.length === 1 && typeArgs.length === 1) {
-          return convertJsonValue(vec[0], typeArgs[0])
-        }
-      }
-      if (typeArgs.length === 1) {
-        return convertJsonValue(value, typeArgs[0])
-      }
-      return value
-
-    default:
-      return value
-  }
-}
-
-/**
  * Converts a view function's JSON response to typed values.
  *
  * @param jsonParsed - Result of JSON.parse(response.data)
@@ -333,12 +287,17 @@ function buildContract(
   context: HasMoveService,
   moduleAddress: string,
   moduleName: string,
-  abi: MoveModuleAbi
+  abi: MoveModuleAbi,
+  opaqueTypes?: string[]
 ): MoveContract {
   const moveClient = context.client.move
 
   // Cache for token decimals by coin type
   const decimalsCache = new Map<string, number>()
+
+  // Resolver for struct ABI lookups (used by resource auto-conversion)
+  const resolver = createAbiResolver(context)
+  const mergedOpaqueTypes = new Set([...DEFAULT_OPAQUE_TYPES, ...(opaqueTypes ?? [])])
 
   // Create execute proxy for entry functions
   const execute = new Proxy({} as MoveExecuteProxy, {
@@ -437,7 +396,7 @@ function buildContract(
     },
   })
 
-  // Query resource
+  // Query resource (auto-converts using ABI resolution)
   async function resource(address: string, structTag: string): Promise<unknown> {
     const response = await moveClient.resource({
       address,
@@ -448,16 +407,22 @@ function buildContract(
       throw new ContractError('move', 0, `Resource not found: ${structTag}`)
     }
 
-    // Parse JSON resource
+    let raw: unknown
     try {
-      return JSON.parse(response.resource.moveResource)
+      raw = JSON.parse(response.resource.moveResource)
     } catch {
       return response.resource.moveResource
     }
+    return convertResourceValue(raw, parseMoveType(structTag), resolver, mergedOpaqueTypes)
   }
 
   // Query table entry
-  async function tableEntry(tableHandle: string, key: unknown, keyType: string): Promise<unknown> {
+  async function tableEntry(
+    tableHandle: string,
+    key: unknown,
+    keyType: string,
+    valueType?: string
+  ): Promise<unknown> {
     // Encode key to BCS bytes
     const keyBytes = encodeMoveArgs([key], [keyType])[0]
 
@@ -471,11 +436,17 @@ function buildContract(
     }
 
     // Parse JSON value
+    let raw: unknown
     try {
-      return JSON.parse(response.tableEntry.value)
+      raw = JSON.parse(response.tableEntry.value)
     } catch {
       return response.tableEntry.value
     }
+
+    if (valueType) {
+      return convertResourceValue(raw, parseMoveType(valueType), resolver, mergedOpaqueTypes)
+    }
+    return raw
   }
 
   // Get decimals for a coin type
@@ -523,7 +494,7 @@ function buildContract(
       name: string
       symbol: string
       decimals: number
-      supply?: { value: string }
+      supply?: { value: bigint }
     }
 
     // Cache decimals
@@ -533,7 +504,7 @@ function buildContract(
       name: coinInfo.name,
       symbol: coinInfo.symbol,
       decimals: coinInfo.decimals,
-      totalSupply: coinInfo.supply ? BigInt(coinInfo.supply.value) : undefined,
+      totalSupply: coinInfo.supply?.value,
     }
   }
 
@@ -634,7 +605,7 @@ export function createMoveContract<T extends ReadonlyMoveModuleAbi>(
         useCache: options.useCache,
         cacheTtl: options.cacheTtl,
       }))
-    return buildContract(context, moduleAddress, moduleName!, fetchedAbi)
+    return buildContract(context, moduleAddress, moduleName!, fetchedAbi, options.opaqueTypes)
   })()
 }
 
@@ -1002,20 +973,30 @@ export async function buildMoveView(
 /**
  * Queries a Move resource directly.
  *
+ * By default, performs automatic type conversion (u64 strings to bigint, Option
+ * unwrapping, etc.) via ABI resolution. Pass `{ convert: false }` to receive
+ * raw JSON-parsed data instead.
+ *
  * @param context - ChainContext with client (must have move service)
  * @param address - Account address
  * @param structTag - Resource struct tag (e.g., '0x1::coin::CoinStore<0x1::native_uinit::Coin>')
+ * @param options - Optional conversion settings
  * @returns Parsed resource data
  *
  * @example
  * ```typescript
- * const resource = await queryResource(ctx, '0x1', '0x1::coin::CoinInfo<...>')
+ * // Auto-converted (default)
+ * const typed = await queryResource(ctx, '0x1', '0x1::coin::CoinInfo<...>')
+ *
+ * // Raw JSON without conversion
+ * const raw = await queryResource(ctx, '0x1', '0x1::coin::CoinInfo<...>', { convert: false })
  * ```
  */
 export async function queryResource(
   context: HasMoveService,
   address: string,
-  structTag: string
+  structTag: string,
+  options?: { convert?: boolean; opaqueTypes?: string[] }
 ): Promise<unknown> {
   const moveClient = context.client.move
   const response = await moveClient.resource({
@@ -1027,11 +1008,20 @@ export async function queryResource(
     throw new ContractError('move', 0, `Resource not found: ${structTag}`)
   }
 
+  let raw: unknown
   try {
-    return JSON.parse(response.resource.moveResource)
+    raw = JSON.parse(response.resource.moveResource)
   } catch {
     return response.resource.moveResource
   }
+
+  if (options?.convert === false) {
+    return raw
+  }
+
+  const resolver = createAbiResolver(context)
+  const opaqueTypes = new Set([...DEFAULT_OPAQUE_TYPES, ...(options?.opaqueTypes ?? [])])
+  return convertResourceValue(raw, parseMoveType(structTag), resolver, opaqueTypes)
 }
 
 /**
@@ -1041,18 +1031,26 @@ export async function queryResource(
  * @param tableHandle - Table handle address
  * @param key - Key value
  * @param keyType - Key type for BCS encoding
- * @returns Parsed table entry value
+ * @param valueType - Optional value type for auto-conversion (e.g., '0x1::stake::StakeInfo')
+ * @param options - Optional settings; pass `opaqueTypes` to skip ABI resolution for specific type bases
+ * @returns Parsed table entry value; auto-converted if valueType is provided
  *
  * @example
  * ```typescript
+ * // Raw result (no conversion)
  * const entry = await queryTableEntry(ctx, tableHandle, key, 'address')
+ *
+ * // With auto-conversion
+ * const typed = await queryTableEntry(ctx, tableHandle, key, 'address', '0x1::stake::StakeInfo')
  * ```
  */
 export async function queryTableEntry(
   context: HasMoveService,
   tableHandle: string,
   key: unknown,
-  keyType: string
+  keyType: string,
+  valueType?: string,
+  options?: { opaqueTypes?: string[] }
 ): Promise<unknown> {
   const moveClient = context.client.move
   const keyBytes = encodeMoveArgs([key], [keyType])[0]
@@ -1066,11 +1064,19 @@ export async function queryTableEntry(
     throw new ContractError('move', 0, `Table entry not found`)
   }
 
+  let raw: unknown
   try {
-    return JSON.parse(response.tableEntry.value)
+    raw = JSON.parse(response.tableEntry.value)
   } catch {
     return response.tableEntry.value
   }
+
+  if (valueType) {
+    const resolver = createAbiResolver(context)
+    const opaqueTypes = new Set([...DEFAULT_OPAQUE_TYPES, ...(options?.opaqueTypes ?? [])])
+    return convertResourceValue(raw, parseMoveType(valueType), resolver, opaqueTypes)
+  }
+  return raw
 }
 
 // =============================================================================

--- a/src/contracts/move/index.ts
+++ b/src/contracts/move/index.ts
@@ -32,7 +32,7 @@ export type {
 } from './types'
 
 // Re-export BSR types
-export type { MsgExecute, MsgScript, MsgPublish } from './types'
+export type { MsgExecute, MsgScript, MsgPublish, TableEntry } from './types'
 export { UpgradePolicy } from './types'
 
 // Contract factory and helpers
@@ -68,10 +68,21 @@ export {
   type FetchAbiOptions,
 } from './abi-fetcher'
 
+// Resource conversion
+export {
+  parseStructTag,
+  createAbiResolver,
+  convertResourceValue,
+  DEFAULT_OPAQUE_TYPES,
+  type ParsedStructTag,
+  type AbiResolver,
+} from './resource-conversion'
+
 // BCS utilities
 export {
   bcs,
   parseMoveType,
+  stringifyType,
   getBcsType,
   encodeMoveArg,
   encodeMoveArgs,

--- a/src/contracts/move/resource-conversion.ts
+++ b/src/contracts/move/resource-conversion.ts
@@ -1,0 +1,258 @@
+/**
+ * Move Resource Conversion Utilities
+ *
+ * Provides struct tag parsing, opaque type definitions, and types
+ * for resource value conversion using module ABIs.
+ */
+
+import {
+  parseMoveType,
+  stringifyType,
+  convertJsonValue,
+  resolveGenericTypes,
+  type ParsedMoveType,
+} from './bcs'
+import { getModuleAbi, findStruct } from './abi-fetcher'
+import type { HasMoveService } from '../../client/types'
+import type { MoveFieldAbi, MoveModuleAbi } from './types'
+
+// =============================================================================
+// Struct Tag Parsing
+// =============================================================================
+
+/**
+ * Parsed struct tag representation.
+ */
+export interface ParsedStructTag {
+  /** Module address (e.g., '0x1') */
+  readonly address: string
+  /** Module name (e.g., 'coin') */
+  readonly module: string
+  /** Struct name (e.g., 'CoinInfo') */
+  readonly name: string
+  /** Type arguments */
+  readonly typeArgs: readonly ParsedMoveType[]
+}
+
+/**
+ * Parses a struct tag string into its components.
+ *
+ * @param tag - Struct tag string (e.g., '0x1::coin::CoinInfo<0x1::native_uinit::Coin>')
+ * @returns Parsed struct tag with address, module, name, and type arguments
+ * @throws Error if the tag does not follow the `address::module::name` format
+ *
+ * @example
+ * ```typescript
+ * parseStructTag('0x1::coin::Coin')
+ * // { address: '0x1', module: 'coin', name: 'Coin', typeArgs: [] }
+ *
+ * parseStructTag('0x1::coin::CoinInfo<0x1::native_uinit::Coin>')
+ * // { address: '0x1', module: 'coin', name: 'CoinInfo', typeArgs: [...] }
+ * ```
+ */
+export function parseStructTag(tag: string): ParsedStructTag {
+  const parsed = parseMoveType(tag)
+  const parts = parsed.base.split('::')
+  if (parts.length !== 3) {
+    throw new Error(`Invalid struct tag: ${tag}. Expected format: address::module::name`)
+  }
+  return {
+    address: parts[0],
+    module: parts[1],
+    name: parts[2],
+    typeArgs: parsed.typeArgs,
+  }
+}
+
+// =============================================================================
+// Opaque Types
+// =============================================================================
+
+/**
+ * Default set of opaque types that should not be recursively resolved.
+ * These types serialize as opaque objects and do not need ABI resolution.
+ *
+ * Entries must be base type strings without type arguments:
+ * - Correct: `'0x1::table::Table'`
+ * - Wrong: `'0x1::table::Table<address, u64>'` (will not match)
+ */
+export const DEFAULT_OPAQUE_TYPES: ReadonlySet<string> = new Set([
+  '0x1::table::Table',
+  '0x1::object::ExtendRef',
+])
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Resolver for fetching struct field ABIs from the chain.
+ */
+export interface AbiResolver {
+  resolveStruct(
+    address: string,
+    moduleName: string,
+    structName: string
+  ): Promise<MoveFieldAbi[] | undefined>
+}
+
+// =============================================================================
+// Resource Value Conversion
+// =============================================================================
+
+/**
+ * Recursively converts a Move resource JSON value to typed JavaScript values
+ * using ABI resolution to determine struct field types.
+ *
+ * Conversion rules:
+ * - **Primitives** (u64/u128/u256 strings, bool, etc.): delegates to `convertJsonValue` (sync)
+ * - **vector\<T\>**: recursively converts each element
+ * - **Option\<T\>**: unwraps `{ vec: [...] }` envelope, returns `null` for empty
+ * - **Opaque types** (e.g., Table): returned as-is, no ABI fetch
+ * - **Custom structs**: fetches field ABI via resolver, recursively converts each field
+ *
+ * @param value - The JSON-parsed resource value
+ * @param parsed - Parsed Move type (use `parseMoveType()` to create)
+ * @param resolver - ABI resolver for fetching struct field definitions
+ * @param opaqueTypes - Set of type bases to skip ABI resolution for
+ * @returns Typed JavaScript value with u64/u128/u256 as bigint, Options unwrapped, etc.
+ *
+ * @example
+ * ```typescript
+ * const resolver = createAbiResolver(ctx)
+ * const typed = await convertResourceValue(
+ *   { value: "12345" },
+ *   parseMoveType('0x1::coin::CoinStore'),
+ *   resolver,
+ *   DEFAULT_OPAQUE_TYPES
+ * )
+ * // typed: { value: 12345n }
+ * ```
+ */
+export async function convertResourceValue(
+  value: unknown,
+  parsed: ParsedMoveType,
+  resolver: AbiResolver,
+  opaqueTypes: ReadonlySet<string>
+): Promise<unknown> {
+  // Step 1: Primitive value -> sync, no ABI fetch
+  if (typeof value !== 'object' || value === null) {
+    return convertJsonValue(value, parsed)
+  }
+
+  // Step 2: Array -> vector handling
+  if (parsed.base === 'vector' && Array.isArray(value) && parsed.typeArgs.length === 1) {
+    return Promise.all(
+      value.map(v => convertResourceValue(v, parsed.typeArgs[0], resolver, opaqueTypes))
+    )
+  }
+
+  // Step 3: Option -> unwrap then recurse
+  if (parsed.base === '0x1::option::Option') {
+    if (value === null || value === undefined) return null
+    if (typeof value === 'object' && value !== null && 'vec' in value) {
+      const vec = (value as { vec: unknown[] }).vec
+      if (vec.length === 0) return null
+      if (vec.length > 1) {
+        throw new Error(
+          `Invalid Option value: vec contains ${vec.length} elements (expected 0 or 1)`
+        )
+      }
+      if (parsed.typeArgs.length === 1) {
+        return convertResourceValue(vec[0], parsed.typeArgs[0], resolver, opaqueTypes)
+      }
+    }
+    // Non-vec Option value — attempt inner type conversion (consistent with convertJsonValue)
+    if (parsed.typeArgs.length === 1) {
+      return convertResourceValue(value, parsed.typeArgs[0], resolver, opaqueTypes)
+    }
+    return value
+  }
+
+  // Step 4: Opaque types -> skip ABI fetch
+  if (opaqueTypes.has(parsed.base)) {
+    return value
+  }
+
+  // Step 5: Custom struct -> ABI resolve + recursive field conversion
+  const parts = parsed.base.split('::')
+  if (parts.length !== 3) {
+    throw new Error(`Unexpected object value for non-struct type '${parsed.base}'`)
+  }
+
+  const [address, module, name] = parts
+  const fields = await resolver.resolveStruct(address, module, name)
+  if (!fields) {
+    throw new Error(`Struct '${name}' not found in ABI for module ${address}::${module}`)
+  }
+
+  // Resolve generic type params (T0, T1, ... -> concrete types)
+  const resolvedTypeStrs = resolveGenericTypes(
+    fields.map(f => f.type),
+    parsed.typeArgs.map(stringifyType)
+  )
+
+  // Recursively convert each field
+  const result = { ...(value as Record<string, unknown>) }
+  await Promise.all(
+    fields.map(async (field, i) => {
+      if (field.name in result) {
+        result[field.name] = await convertResourceValue(
+          result[field.name],
+          parseMoveType(resolvedTypeStrs[i]),
+          resolver,
+          opaqueTypes
+        )
+      }
+    })
+  )
+  return result
+}
+
+// =============================================================================
+// ABI Resolver Factory
+// =============================================================================
+
+/**
+ * Creates an ABI resolver with in-flight request deduplication.
+ *
+ * Wraps `getModuleAbi()` + `findStruct()` to resolve struct fields from the chain.
+ * Concurrent requests for the same module are deduplicated so only one gRPC call
+ * is made. Errors from `getModuleAbi` propagate to the caller.
+ *
+ * @param context - Context with Move service access
+ * @returns AbiResolver instance
+ *
+ * @example
+ * ```typescript
+ * const resolver = createAbiResolver(ctx)
+ * const fields = await resolver.resolveStruct('0x1', 'coin', 'CoinInfo')
+ * // fields: [{ name: 'value', type: 'u64' }] or undefined
+ * ```
+ */
+export function createAbiResolver(context: HasMoveService): AbiResolver {
+  const inflight = new Map<string, Promise<MoveModuleAbi>>()
+
+  async function fetchAbi(address: string, moduleName: string): Promise<MoveModuleAbi> {
+    const key = `${address.toLowerCase()}::${moduleName}`
+    let promise = inflight.get(key)
+    if (!promise) {
+      promise = getModuleAbi(context, address, moduleName)
+      inflight.set(key, promise)
+      // Clean up inflight entry on settle. Errors propagate via `return promise` below,
+      // not through this .then() chain — the rejection handler only removes the cache entry.
+      promise.then(
+        () => inflight.delete(key),
+        () => inflight.delete(key)
+      )
+    }
+    return promise
+  }
+
+  return {
+    async resolveStruct(address, moduleName, structName) {
+      const abi = await fetchAbi(address, moduleName)
+      return findStruct(abi, structName)?.fields
+    },
+  }
+}

--- a/src/contracts/move/types.ts
+++ b/src/contracts/move/types.ts
@@ -198,9 +198,15 @@ export interface MoveContract {
    * @param tableHandle - Table handle address
    * @param key - Key value (will be BCS encoded)
    * @param keyType - Key type for BCS encoding
-   * @returns Parsed value
+   * @param valueType - Optional value type for auto-conversion. Omit for raw JSON-parsed data.
+   * @returns Parsed value; auto-converted if valueType is provided
    */
-  tableEntry(tableHandle: string, key: unknown, keyType: string): Promise<unknown>
+  tableEntry(
+    tableHandle: string,
+    key: unknown,
+    keyType: string,
+    valueType?: string
+  ): Promise<unknown>
 
   /**
    * Parse a human-readable amount to minimum units for a specific coin type
@@ -291,6 +297,7 @@ export type MoveClient = Client<typeof MoveQuery>
  * MsgPublish is used for publishing Move modules.
  */
 export type { MsgExecuteJSON as MsgExecute, MsgScriptJSON as MsgScript, MsgPublish }
+export type { TableEntry } from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/types_pb'
 export { UpgradePolicy } from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/types_pb'
 
 // =============================================================================

--- a/test/unit/contracts/move/bcs.spec.ts
+++ b/test/unit/contracts/move/bcs.spec.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from 'vitest'
 import {
   bcs,
   parseMoveType,
+  stringifyType,
   getBcsType,
   encodeMoveArg,
   encodeMoveArgs,
@@ -65,6 +66,67 @@ describe('Move BCS', () => {
 
     it('should handle whitespace', () => {
       expect(parseMoveType('  u64  ')).toEqual({ base: 'u64', typeArgs: [] })
+    })
+  })
+
+  describe('stringifyType', () => {
+    it('should stringify primitive types', () => {
+      expect(stringifyType({ base: 'u64', typeArgs: [] })).toBe('u64')
+    })
+
+    it('should stringify simple generic types', () => {
+      expect(stringifyType({ base: 'vector', typeArgs: [{ base: 'u8', typeArgs: [] }] })).toBe(
+        'vector<u8>'
+      )
+    })
+
+    it('should stringify nested generic types', () => {
+      expect(
+        stringifyType({
+          base: 'vector',
+          typeArgs: [{ base: 'vector', typeArgs: [{ base: 'u8', typeArgs: [] }] }],
+        })
+      ).toBe('vector<vector<u8>>')
+    })
+
+    it('should stringify module types without type args', () => {
+      expect(stringifyType({ base: '0x1::coin::Coin', typeArgs: [] })).toBe('0x1::coin::Coin')
+    })
+
+    it('should stringify module types with type args', () => {
+      expect(
+        stringifyType({
+          base: '0x1::coin::CoinInfo',
+          typeArgs: [{ base: '0x1::native_uinit::Coin', typeArgs: [] }],
+        })
+      ).toBe('0x1::coin::CoinInfo<0x1::native_uinit::Coin>')
+    })
+
+    it('should stringify multiple type args', () => {
+      expect(
+        stringifyType({
+          base: '0x1::table::Table',
+          typeArgs: [
+            { base: 'address', typeArgs: [] },
+            { base: 'u64', typeArgs: [] },
+          ],
+        })
+      ).toBe('0x1::table::Table<address, u64>')
+    })
+
+    it('should round-trip with parseMoveType', () => {
+      const inputs = [
+        'u64',
+        'vector<u8>',
+        'vector<vector<u8>>',
+        '0x1::coin::Coin',
+        '0x1::option::Option<u64>',
+        '0x1::coin::CoinStore<0x1::native_uinit::Coin>',
+        '0x1::table::Table<address, u64>',
+      ]
+      for (const input of inputs) {
+        expect(stringifyType(parseMoveType(input))).toBe(input)
+      }
     })
   })
 

--- a/test/unit/contracts/move/contract.spec.ts
+++ b/test/unit/contracts/move/contract.spec.ts
@@ -441,6 +441,26 @@ describe('Move Contract', () => {
   describe('resource query', () => {
     it('should query and parse resource', async () => {
       const mockMoveClient = createDefaultMockMoveClient()
+      // Add CoinStore struct to ABI so conversion succeeds
+      mockMoveClient.module.mockResolvedValue({
+        module: {
+          abi: JSON.stringify({
+            address: '0x1',
+            name: 'coin',
+            friends: [],
+            exposed_functions: [],
+            structs: [
+              {
+                name: 'CoinStore',
+                is_native: false,
+                abilities: ['key'],
+                generic_type_params: [{ constraints: [] }],
+                fields: [{ name: 'value', type: 'u64' }],
+              },
+            ],
+          }),
+        },
+      })
       const contract = await createMoveContract(createMockContext(mockMoveClient), '0x1', 'coin')
 
       const result = await contract.resource(
@@ -452,7 +472,7 @@ describe('Move Contract', () => {
         address: 'init1address...',
         structTag: '0x1::coin::CoinStore<0x1::native_uinit::Coin>',
       })
-      expect(result).toEqual({ value: '1000000' })
+      expect(result).toEqual({ value: 1000000n })
     })
 
     it('should throw if resource not found', async () => {
@@ -463,6 +483,150 @@ describe('Move Contract', () => {
       await expect(
         contract.resource('init1address...', '0x1::nonexistent::Resource')
       ).rejects.toThrow('Resource not found')
+    })
+
+    it('should auto-convert u64 fields when struct ABI is available', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      // Return a resource with a u64 field as string (chain JSON format)
+      mockMoveClient.resource.mockResolvedValue({
+        resource: { moveResource: '{"value":"12345"}' },
+      })
+      // Mock module to return ABI with a struct that has a u64 field
+      mockMoveClient.module.mockResolvedValue({
+        module: {
+          abi: JSON.stringify({
+            address: '0x1',
+            name: 'coin',
+            friends: [],
+            exposed_functions: [],
+            structs: [
+              {
+                name: 'CoinStore',
+                is_native: false,
+                abilities: ['key'],
+                generic_type_params: [],
+                fields: [{ name: 'value', type: 'u64' }],
+              },
+            ],
+          }),
+        },
+      })
+
+      const contract = await createMoveContract(createMockContext(mockMoveClient), '0x1', 'coin')
+      const result = await contract.resource('init1address...', '0x1::coin::CoinStore')
+
+      // u64 string "12345" should be converted to bigint 12345n
+      expect(result).toEqual({ value: 12345n })
+    })
+
+    it('should skip opaque types like Table without resolving', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      // Resource with a Table field (should remain as-is)
+      mockMoveClient.resource.mockResolvedValue({
+        resource: {
+          moveResource: JSON.stringify({
+            balance: '999',
+            ledger: { handle: '0xabc' },
+          }),
+        },
+      })
+      // Mock module returns struct with a u64 field and a Table field
+      mockMoveClient.module.mockResolvedValue({
+        module: {
+          abi: JSON.stringify({
+            address: '0x1',
+            name: 'account',
+            friends: [],
+            exposed_functions: [],
+            structs: [
+              {
+                name: 'Account',
+                is_native: false,
+                abilities: ['key'],
+                generic_type_params: [],
+                fields: [
+                  { name: 'balance', type: 'u64' },
+                  { name: 'ledger', type: '0x1::table::Table<address, u64>' },
+                ],
+              },
+            ],
+          }),
+        },
+      })
+
+      const contract = await createMoveContract(createMockContext(mockMoveClient), '0x1', 'account')
+      const result = await contract.resource('init1address...', '0x1::account::Account')
+
+      // balance should be converted (u64), but Table should remain as-is
+      expect(result).toEqual({
+        balance: 999n,
+        ledger: { handle: '0xabc' },
+      })
+    })
+
+    it('should propagate conversion errors instead of silently returning raw data', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.resource.mockResolvedValue({
+        resource: { moveResource: '{"value":"100"}' },
+      })
+
+      // First call succeeds (contract creation), subsequent calls fail (resource conversion)
+      const contract = await createMoveContract(createMockContext(mockMoveClient), '0x1', 'coin')
+      mockMoveClient.module.mockRejectedValue(new Error('gRPC unavailable'))
+
+      await expect(contract.resource('init1address...', '0x1::other::Struct')).rejects.toThrow(
+        'gRPC unavailable'
+      )
+    })
+  })
+
+  describe('CreateMoveContractOptions', () => {
+    it('should accept opaqueTypes option', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      // Resource with a custom opaque field
+      mockMoveClient.resource.mockResolvedValue({
+        resource: {
+          moveResource: JSON.stringify({
+            value: '100',
+            custom: { inner: 'data' },
+          }),
+        },
+      })
+      // Mock struct with u64 field and a custom struct field
+      mockMoveClient.module.mockResolvedValue({
+        module: {
+          abi: JSON.stringify({
+            address: '0x1',
+            name: 'test',
+            friends: [],
+            exposed_functions: [],
+            structs: [
+              {
+                name: 'MyResource',
+                is_native: false,
+                abilities: ['key'],
+                generic_type_params: [],
+                fields: [
+                  { name: 'value', type: 'u64' },
+                  { name: 'custom', type: '0x1::custom::Opaque' },
+                ],
+              },
+            ],
+          }),
+        },
+      })
+
+      const contract = await createMoveContract(createMockContext(mockMoveClient), '0x1', 'test', {
+        opaqueTypes: ['0x1::custom::Opaque'],
+      })
+
+      const result = await contract.resource('init1address...', '0x1::test::MyResource')
+
+      // value converted, custom skipped because it's in opaqueTypes
+      expect(result).toEqual({
+        value: 100n,
+        custom: { inner: 'data' },
+      })
     })
   })
 
@@ -485,6 +649,58 @@ describe('Move Contract', () => {
       await expect(contract.tableEntry('0xtable', 'key', 'string')).rejects.toThrow(
         'Table entry not found'
       )
+    })
+
+    it('should auto-convert u64 fields when valueType is provided', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.tableEntry.mockResolvedValue({
+        tableEntry: { value: '{"amount":"100"}' },
+      })
+      // Mock module to return struct ABI with a u64 field
+      mockMoveClient.module.mockResolvedValue({
+        module: {
+          abi: JSON.stringify({
+            address: '0x1',
+            name: 'some',
+            friends: [],
+            exposed_functions: [],
+            structs: [
+              {
+                name: 'Type',
+                is_native: false,
+                abilities: ['key'],
+                generic_type_params: [],
+                fields: [{ name: 'amount', type: 'u64' }],
+              },
+            ],
+          }),
+        },
+      })
+
+      const contract = await createMoveContract(createMockContext(mockMoveClient), '0x1', 'some')
+
+      const result = await contract.tableEntry(
+        '0xtablehandle',
+        'mykey',
+        'string',
+        '0x1::some::Type'
+      )
+
+      expect(result).toEqual({ amount: 100n })
+    })
+
+    it('should not convert values when valueType is not provided', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.tableEntry.mockResolvedValue({
+        tableEntry: { value: '{"amount":"100"}' },
+      })
+
+      const contract = await createMoveContract(createMockContext(mockMoveClient), '0x1', 'coin')
+
+      const result = await contract.tableEntry('0xtablehandle', 'mykey', 'string')
+
+      // Without valueType, u64 string remains a string
+      expect(result).toEqual({ amount: '100' })
     })
   })
 
@@ -659,6 +875,25 @@ describe('Move Contract', () => {
   describe('queryResource', () => {
     it('should query resource directly', async () => {
       const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.module.mockResolvedValue({
+        module: {
+          abi: JSON.stringify({
+            address: '0x1',
+            name: 'coin',
+            friends: [],
+            exposed_functions: [],
+            structs: [
+              {
+                name: 'CoinStore',
+                is_native: false,
+                abilities: ['key'],
+                generic_type_params: [{ constraints: [] }],
+                fields: [{ name: 'value', type: 'u64' }],
+              },
+            ],
+          }),
+        },
+      })
 
       const result = await queryResource(
         createMockContext(mockMoveClient),
@@ -666,7 +901,7 @@ describe('Move Contract', () => {
         '0x1::coin::CoinStore<0x1::native_uinit::Coin>'
       )
 
-      expect(result).toEqual({ value: '1000000' })
+      expect(result).toEqual({ value: 1000000n })
     })
 
     it('should throw if resource not found', async () => {
@@ -680,6 +915,119 @@ describe('Move Contract', () => {
           '0x1::nonexistent::Resource'
         )
       ).rejects.toThrow('Resource not found')
+    })
+
+    it('should auto-convert u64 strings to bigint by default', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.resource.mockResolvedValue({
+        resource: { moveResource: '{"value":"12345"}' },
+      })
+      // Mock module to return struct ABI with u64 field
+      mockMoveClient.module.mockResolvedValue({
+        module: {
+          abi: JSON.stringify({
+            address: '0x1',
+            name: 'coin',
+            friends: [],
+            exposed_functions: [],
+            structs: [
+              {
+                name: 'CoinStore',
+                is_native: false,
+                abilities: ['key'],
+                generic_type_params: [],
+                fields: [{ name: 'value', type: 'u64' }],
+              },
+            ],
+          }),
+        },
+      })
+
+      const result = await queryResource(
+        createMockContext(mockMoveClient),
+        'init1address...',
+        '0x1::coin::CoinStore'
+      )
+
+      // u64 string "12345" should be converted to bigint by default
+      expect(result).toEqual({ value: 12345n })
+    })
+
+    it('should not convert values when convert: false', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.resource.mockResolvedValue({
+        resource: { moveResource: '{"value":"12345"}' },
+      })
+
+      const result = await queryResource(
+        createMockContext(mockMoveClient),
+        'init1address...',
+        '0x1::coin::CoinStore',
+        { convert: false }
+      )
+
+      // With convert: false, u64 string remains a string
+      expect(result).toEqual({ value: '12345' })
+    })
+
+    it('should respect opaqueTypes option when converting', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.resource.mockResolvedValue({
+        resource: {
+          moveResource: JSON.stringify({
+            balance: '500',
+            data: { inner: 'opaque' },
+          }),
+        },
+      })
+      // Mock module to return struct ABI
+      mockMoveClient.module.mockResolvedValue({
+        module: {
+          abi: JSON.stringify({
+            address: '0x1',
+            name: 'test',
+            friends: [],
+            exposed_functions: [],
+            structs: [
+              {
+                name: 'MyStruct',
+                is_native: false,
+                abilities: ['key'],
+                generic_type_params: [],
+                fields: [
+                  { name: 'balance', type: 'u64' },
+                  { name: 'data', type: '0x1::custom::Opaque' },
+                ],
+              },
+            ],
+          }),
+        },
+      })
+
+      const result = await queryResource(
+        createMockContext(mockMoveClient),
+        'init1address...',
+        '0x1::test::MyStruct',
+        { convert: true, opaqueTypes: ['0x1::custom::Opaque'] }
+      )
+
+      // balance converted, custom opaque type skipped
+      expect(result).toEqual({
+        balance: 500n,
+        data: { inner: 'opaque' },
+      })
+    })
+
+    it('should propagate conversion errors instead of silently returning raw data', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.resource.mockResolvedValue({
+        resource: { moveResource: '{"value":"100"}' },
+      })
+      mockMoveClient.module.mockRejectedValue(new Error('gRPC unavailable'))
+
+      await expect(
+        queryResource(createMockContext(mockMoveClient), 'init1address...', '0x1::other::Struct')
+      ).rejects.toThrow('gRPC unavailable')
     })
   })
 
@@ -695,6 +1043,122 @@ describe('Move Contract', () => {
       )
 
       expect(result).toEqual({ key: 'value' })
+    })
+
+    it('should not convert values when valueType is not provided', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.tableEntry.mockResolvedValue({
+        tableEntry: { value: '{"amount":"999"}' },
+      })
+
+      const result = await queryTableEntry(
+        createMockContext(mockMoveClient),
+        '0xtable',
+        'mykey',
+        'string'
+      )
+
+      // Without valueType, u64 string remains a string
+      expect(result).toEqual({ amount: '999' })
+    })
+
+    it('should convert u64 strings to bigint when valueType is provided', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.tableEntry.mockResolvedValue({
+        tableEntry: { value: '{"amount":"999"}' },
+      })
+      // Mock module to return struct ABI with u64 field
+      mockMoveClient.module.mockResolvedValue({
+        module: {
+          abi: JSON.stringify({
+            address: '0x1',
+            name: 'stake',
+            friends: [],
+            exposed_functions: [],
+            structs: [
+              {
+                name: 'StakeInfo',
+                is_native: false,
+                abilities: ['key'],
+                generic_type_params: [],
+                fields: [{ name: 'amount', type: 'u64' }],
+              },
+            ],
+          }),
+        },
+      })
+
+      const result = await queryTableEntry(
+        createMockContext(mockMoveClient),
+        '0xtable',
+        'mykey',
+        'string',
+        '0x1::stake::StakeInfo'
+      )
+
+      // u64 string "999" should be converted to bigint
+      expect(result).toEqual({ amount: 999n })
+    })
+
+    it('should respect opaqueTypes option when converting', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.tableEntry.mockResolvedValue({
+        tableEntry: { value: '{"balance":"100","data":{"inner":"opaque"}}' },
+      })
+      mockMoveClient.module.mockResolvedValue({
+        module: {
+          abi: JSON.stringify({
+            address: '0x1',
+            name: 'test',
+            friends: [],
+            exposed_functions: [],
+            structs: [
+              {
+                name: 'Entry',
+                is_native: false,
+                abilities: ['key'],
+                generic_type_params: [],
+                fields: [
+                  { name: 'balance', type: 'u64' },
+                  { name: 'data', type: '0x1::custom::Opaque' },
+                ],
+              },
+            ],
+          }),
+        },
+      })
+
+      const result = await queryTableEntry(
+        createMockContext(mockMoveClient),
+        '0xtable',
+        'mykey',
+        'string',
+        '0x1::test::Entry',
+        { opaqueTypes: ['0x1::custom::Opaque'] }
+      )
+
+      expect(result).toEqual({
+        balance: 100n,
+        data: { inner: 'opaque' },
+      })
+    })
+
+    it('should propagate ABI fetch errors when valueType is provided', async () => {
+      const mockMoveClient = createDefaultMockMoveClient()
+      mockMoveClient.tableEntry.mockResolvedValue({
+        tableEntry: { value: '{"amount":"100"}' },
+      })
+      mockMoveClient.module.mockRejectedValue(new Error('gRPC unavailable'))
+
+      await expect(
+        queryTableEntry(
+          createMockContext(mockMoveClient),
+          '0xtable',
+          'mykey',
+          'string',
+          '0x1::stake::StakeInfo'
+        )
+      ).rejects.toThrow('gRPC unavailable')
     })
   })
 })

--- a/test/unit/contracts/move/resource-conversion.spec.ts
+++ b/test/unit/contracts/move/resource-conversion.spec.ts
@@ -1,0 +1,600 @@
+/**
+ * Resource Conversion Tests
+ *
+ * Tests for parseStructTag(), DEFAULT_OPAQUE_TYPES, createAbiResolver(),
+ * convertResourceValue(), and related types.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  parseStructTag,
+  DEFAULT_OPAQUE_TYPES,
+  createAbiResolver,
+  convertResourceValue,
+  type ParsedStructTag,
+  type AbiResolver,
+} from '../../../../src/contracts/move/resource-conversion'
+import { parseMoveType } from '../../../../src/contracts/move/bcs'
+import { getModuleAbi, findStruct } from '../../../../src/contracts/move/abi-fetcher'
+import type { HasMoveService } from '../../../../src/client/types'
+import type { MoveModuleAbi, MoveFieldAbi } from '../../../../src/contracts/move/types'
+
+vi.mock('../../../../src/contracts/move/abi-fetcher', () => ({
+  getModuleAbi: vi.fn(),
+  findStruct: vi.fn(),
+}))
+
+describe('Resource Conversion', () => {
+  describe('parseStructTag', () => {
+    it('should parse a simple struct tag without type args', () => {
+      const result = parseStructTag('0x1::coin::Coin')
+      expect(result).toEqual({
+        address: '0x1',
+        module: 'coin',
+        name: 'Coin',
+        typeArgs: [],
+      })
+    })
+
+    it('should parse a struct tag with a single type arg', () => {
+      const result = parseStructTag('0x1::coin::CoinInfo<0x1::native_uinit::Coin>')
+      expect(result).toEqual({
+        address: '0x1',
+        module: 'coin',
+        name: 'CoinInfo',
+        typeArgs: [{ base: '0x1::native_uinit::Coin', typeArgs: [] }],
+      })
+    })
+
+    it('should parse a struct tag with multiple type args', () => {
+      const result = parseStructTag('0x1::table::Table<address, u64>')
+      expect(result).toEqual({
+        address: '0x1',
+        module: 'table',
+        name: 'Table',
+        typeArgs: [
+          { base: 'address', typeArgs: [] },
+          { base: 'u64', typeArgs: [] },
+        ],
+      })
+    })
+
+    it('should parse a struct tag with nested type args', () => {
+      const result = parseStructTag('0x1::coin::CoinInfo<0x1::option::Option<u64>>')
+      expect(result).toEqual({
+        address: '0x1',
+        module: 'coin',
+        name: 'CoinInfo',
+        typeArgs: [
+          {
+            base: '0x1::option::Option',
+            typeArgs: [{ base: 'u64', typeArgs: [] }],
+          },
+        ],
+      })
+    })
+
+    it('should throw on invalid format with single part', () => {
+      expect(() => parseStructTag('invalid')).toThrow(
+        'Invalid struct tag: invalid. Expected format: address::module::name'
+      )
+    })
+
+    it('should throw on invalid format with two parts', () => {
+      expect(() => parseStructTag('0x1::coin')).toThrow(
+        'Invalid struct tag: 0x1::coin. Expected format: address::module::name'
+      )
+    })
+  })
+
+  describe('DEFAULT_OPAQUE_TYPES', () => {
+    it('should contain 0x1::table::Table', () => {
+      expect(DEFAULT_OPAQUE_TYPES.has('0x1::table::Table')).toBe(true)
+    })
+
+    it('should contain 0x1::object::ExtendRef', () => {
+      expect(DEFAULT_OPAQUE_TYPES.has('0x1::object::ExtendRef')).toBe(true)
+    })
+  })
+
+  describe('type exports', () => {
+    it('should export AbiResolver interface (compile-time check)', () => {
+      // Type-level verification: AbiResolver has resolveStruct method
+      const _resolver: AbiResolver = {
+        resolveStruct: async (_addr, _mod, _struct) => undefined,
+      }
+      expect(_resolver).toBeDefined()
+    })
+
+    it('should export ParsedStructTag interface (compile-time check)', () => {
+      const _tag: ParsedStructTag = {
+        address: '0x1',
+        module: 'coin',
+        name: 'Coin',
+        typeArgs: [],
+      }
+      expect(_tag).toBeDefined()
+    })
+  })
+
+  describe('createAbiResolver', () => {
+    const mockContext = { client: { move: {} } } as unknown as HasMoveService
+    const mockGetModuleAbi = vi.mocked(getModuleAbi)
+    const mockFindStruct = vi.mocked(findStruct)
+
+    const coinFields: MoveFieldAbi[] = [{ name: 'value', type: 'u64' }]
+
+    const coinAbi: MoveModuleAbi = {
+      address: '0x1',
+      name: 'coin',
+      friends: [],
+      exposed_functions: [],
+      structs: [
+        {
+          name: 'CoinInfo',
+          is_native: false,
+          abilities: ['key'],
+          generic_type_params: [],
+          fields: coinFields,
+        },
+      ],
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('should return struct fields when module and struct exist', async () => {
+      mockGetModuleAbi.mockResolvedValue(coinAbi)
+      mockFindStruct.mockReturnValue(coinAbi.structs[0])
+
+      const resolver = createAbiResolver(mockContext)
+      const fields = await resolver.resolveStruct('0x1', 'coin', 'CoinInfo')
+
+      expect(fields).toEqual(coinFields)
+      expect(mockGetModuleAbi).toHaveBeenCalledWith(mockContext, '0x1', 'coin')
+      expect(mockFindStruct).toHaveBeenCalledWith(coinAbi, 'CoinInfo')
+    })
+
+    it('should return undefined when struct is not found in module', async () => {
+      mockGetModuleAbi.mockResolvedValue(coinAbi)
+      mockFindStruct.mockReturnValue(undefined)
+
+      const resolver = createAbiResolver(mockContext)
+      const fields = await resolver.resolveStruct('0x1', 'coin', 'NonExistent')
+
+      expect(fields).toBeUndefined()
+    })
+
+    it('should propagate errors when getModuleAbi throws', async () => {
+      mockGetModuleAbi.mockRejectedValue(new Error('Module not found'))
+
+      const resolver = createAbiResolver(mockContext)
+
+      await expect(resolver.resolveStruct('0x1', 'missing', 'Foo')).rejects.toThrow(
+        'Module not found'
+      )
+    })
+
+    it('should deduplicate concurrent requests for the same module', async () => {
+      mockGetModuleAbi.mockResolvedValue(coinAbi)
+      mockFindStruct.mockReturnValue(coinAbi.structs[0])
+
+      const resolver = createAbiResolver(mockContext)
+
+      // Fire two concurrent requests for the same module
+      const [result1, result2] = await Promise.all([
+        resolver.resolveStruct('0x1', 'coin', 'CoinInfo'),
+        resolver.resolveStruct('0x1', 'coin', 'CoinInfo'),
+      ])
+
+      expect(result1).toEqual(coinFields)
+      expect(result2).toEqual(coinFields)
+      // Only one gRPC call should have been made
+      expect(mockGetModuleAbi).toHaveBeenCalledTimes(1)
+    })
+
+    it('should make separate requests for different modules', async () => {
+      const stakingAbi: MoveModuleAbi = {
+        address: '0x1',
+        name: 'staking',
+        friends: [],
+        exposed_functions: [],
+        structs: [
+          {
+            name: 'StakeInfo',
+            is_native: false,
+            abilities: ['key'],
+            generic_type_params: [],
+            fields: [{ name: 'amount', type: 'u64' }],
+          },
+        ],
+      }
+
+      mockGetModuleAbi.mockResolvedValueOnce(coinAbi).mockResolvedValueOnce(stakingAbi)
+      mockFindStruct
+        .mockReturnValueOnce(coinAbi.structs[0])
+        .mockReturnValueOnce(stakingAbi.structs[0])
+
+      const resolver = createAbiResolver(mockContext)
+
+      const [fields1, fields2] = await Promise.all([
+        resolver.resolveStruct('0x1', 'coin', 'CoinInfo'),
+        resolver.resolveStruct('0x1', 'staking', 'StakeInfo'),
+      ])
+
+      expect(fields1).toEqual(coinFields)
+      expect(fields2).toEqual([{ name: 'amount', type: 'u64' }])
+      expect(mockGetModuleAbi).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('convertResourceValue', () => {
+    /**
+     * Helper to create a mock AbiResolver from a struct name → fields map.
+     * No mocking of getModuleAbi needed — the resolver is the direct interface.
+     */
+    function createMockResolver(structs: Record<string, MoveFieldAbi[]>): AbiResolver {
+      return {
+        async resolveStruct(_addr, _mod, name) {
+          return structs[name]
+        },
+      }
+    }
+
+    const emptyResolver = createMockResolver({})
+    const emptyOpaqueTypes = new Set<string>()
+
+    // ---------------------------------------------------------------
+    // Primitive conversions
+    // ---------------------------------------------------------------
+
+    it('should convert u64 string to bigint', async () => {
+      const result = await convertResourceValue(
+        '12345',
+        parseMoveType('u64'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toBe(12345n)
+    })
+
+    it('should convert u128 string to bigint', async () => {
+      const result = await convertResourceValue(
+        '99999999999999999999',
+        parseMoveType('u128'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toBe(99999999999999999999n)
+    })
+
+    it('should convert u256 string to bigint', async () => {
+      const result = await convertResourceValue(
+        '42',
+        parseMoveType('u256'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toBe(42n)
+    })
+
+    it('should pass through bool values unchanged', async () => {
+      const result = await convertResourceValue(
+        true,
+        parseMoveType('bool'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toBe(true)
+    })
+
+    it('should pass through string values for 0x1::string::String', async () => {
+      const result = await convertResourceValue(
+        'hello',
+        parseMoveType('0x1::string::String'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toBe('hello')
+    })
+
+    it('should pass through number values for u8', async () => {
+      const result = await convertResourceValue(
+        42,
+        parseMoveType('u8'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toBe(42)
+    })
+
+    it('should defensively convert u8/u16/u32 string values to number', async () => {
+      const r8 = await convertResourceValue(
+        '42',
+        parseMoveType('u8'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(r8).toBe(42)
+      expect(typeof r8).toBe('number')
+
+      const r16 = await convertResourceValue(
+        '1000',
+        parseMoveType('u16'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(r16).toBe(1000)
+
+      const r32 = await convertResourceValue(
+        '65535',
+        parseMoveType('u32'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(r32).toBe(65535)
+    })
+
+    // ---------------------------------------------------------------
+    // vector conversions
+    // ---------------------------------------------------------------
+
+    it('should convert vector<u64> elements to bigint', async () => {
+      const result = await convertResourceValue(
+        ['1', '2', '3'],
+        parseMoveType('vector<u64>'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual([1n, 2n, 3n])
+    })
+
+    it('should handle empty vector', async () => {
+      const result = await convertResourceValue(
+        [],
+        parseMoveType('vector<u64>'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual([])
+    })
+
+    it('should handle nested vector<vector<u64>>', async () => {
+      const result = await convertResourceValue(
+        [['1', '2'], ['3']],
+        parseMoveType('vector<vector<u64>>'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual([[1n, 2n], [3n]])
+    })
+
+    // ---------------------------------------------------------------
+    // Option conversions
+    // ---------------------------------------------------------------
+
+    it('should convert Option<u64> with a value', async () => {
+      const result = await convertResourceValue(
+        { vec: ['42'] },
+        parseMoveType('0x1::option::Option<u64>'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toBe(42n)
+    })
+
+    it('should convert empty Option<u64> to null', async () => {
+      const result = await convertResourceValue(
+        { vec: [] },
+        parseMoveType('0x1::option::Option<u64>'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toBeNull()
+    })
+
+    // ---------------------------------------------------------------
+    // Opaque type handling
+    // ---------------------------------------------------------------
+
+    it('should return opaque types as-is without ABI resolution', async () => {
+      const tableValue = { handle: '0x123' }
+      const opaqueTypes = new Set(['0x1::table::Table'])
+
+      const result = await convertResourceValue(
+        tableValue,
+        parseMoveType('0x1::table::Table<address, u64>'),
+        emptyResolver,
+        opaqueTypes
+      )
+      expect(result).toEqual({ handle: '0x123' })
+    })
+
+    // ---------------------------------------------------------------
+    // Custom struct with field conversion
+    // ---------------------------------------------------------------
+
+    it('should convert custom struct fields using ABI', async () => {
+      const resolver = createMockResolver({
+        CoinStore: [{ name: 'value', type: 'u64' }],
+      })
+
+      const result = await convertResourceValue(
+        { value: '100' },
+        parseMoveType('0x1::coin::CoinStore'),
+        resolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual({ value: 100n })
+    })
+
+    it('should handle nested structs recursively', async () => {
+      const resolver = createMockResolver({
+        Outer: [{ name: 'coin', type: '0x1::coin::Inner' }],
+        Inner: [{ name: 'value', type: 'u64' }],
+      })
+
+      const result = await convertResourceValue(
+        { coin: { value: '50' } },
+        parseMoveType('0x1::coin::Outer'),
+        resolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual({ coin: { value: 50n } })
+    })
+
+    it('should resolve generic type params in struct fields', async () => {
+      // CoinInfo<T0> has field { name: 'value', type: 'T0' }
+      // When instantiated as CoinInfo<u64>, T0 → u64
+      const resolver = createMockResolver({
+        CoinInfo: [{ name: 'value', type: 'T0' }],
+      })
+
+      const result = await convertResourceValue(
+        { value: '99' },
+        parseMoveType('0x1::coin::CoinInfo<u64>'),
+        resolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual({ value: 99n })
+    })
+
+    it('should resolve multiple generic type params', async () => {
+      const resolver = createMockResolver({
+        Pair: [
+          { name: 'first', type: 'T0' },
+          { name: 'second', type: 'T1' },
+        ],
+      })
+
+      const result = await convertResourceValue(
+        { first: '10', second: true },
+        parseMoveType('0x1::util::Pair<u64, bool>'),
+        resolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual({ first: 10n, second: true })
+    })
+
+    // ---------------------------------------------------------------
+    // Graceful fallback
+    // ---------------------------------------------------------------
+
+    it('should throw when struct is not found in ABI', async () => {
+      await expect(
+        convertResourceValue(
+          { value: '100' },
+          parseMoveType('0x1::unknown::Mystery'),
+          emptyResolver,
+          emptyOpaqueTypes
+        )
+      ).rejects.toThrow("Struct 'Mystery' not found in ABI for module 0x1::unknown")
+    })
+
+    it('should throw for object value with non-struct type', async () => {
+      await expect(
+        convertResourceValue(
+          { some: 'data' },
+          parseMoveType('SomeType'),
+          emptyResolver,
+          emptyOpaqueTypes
+        )
+      ).rejects.toThrow("Unexpected object value for non-struct type 'SomeType'")
+    })
+
+    // ---------------------------------------------------------------
+    // Extra fields preserved
+    // ---------------------------------------------------------------
+
+    it('should preserve extra fields not in the ABI', async () => {
+      const resolver = createMockResolver({
+        CoinStore: [{ name: 'value', type: 'u64' }],
+      })
+
+      const result = await convertResourceValue(
+        { value: '100', extra: 'keep', another: 42 },
+        parseMoveType('0x1::coin::CoinStore'),
+        resolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual({ value: 100n, extra: 'keep', another: 42 })
+    })
+
+    // ---------------------------------------------------------------
+    // Complex / edge cases
+    // ---------------------------------------------------------------
+
+    it('should handle struct with Option field', async () => {
+      const resolver = createMockResolver({
+        Config: [
+          { name: 'enabled', type: 'bool' },
+          { name: 'limit', type: '0x1::option::Option<u64>' },
+        ],
+      })
+
+      const result = await convertResourceValue(
+        { enabled: true, limit: { vec: ['1000'] } },
+        parseMoveType('0x1::config::Config'),
+        resolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual({ enabled: true, limit: 1000n })
+    })
+
+    it('should handle Option<CustomStruct> with ABI resolution on inner type', async () => {
+      const resolver = createMockResolver({
+        Wrapper: [{ name: 'inner', type: '0x1::option::Option<0x1::coin::Balance>' }],
+        Balance: [{ name: 'amount', type: 'u64' }],
+      })
+
+      const result = await convertResourceValue(
+        { inner: { vec: [{ amount: '500' }] } },
+        parseMoveType('0x1::coin::Wrapper'),
+        resolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual({ inner: { amount: 500n } })
+    })
+
+    it('should handle empty Option<CustomStruct>', async () => {
+      const resolver = createMockResolver({
+        Wrapper: [{ name: 'inner', type: '0x1::option::Option<0x1::coin::Balance>' }],
+        Balance: [{ name: 'amount', type: 'u64' }],
+      })
+
+      const result = await convertResourceValue(
+        { inner: { vec: [] } },
+        parseMoveType('0x1::coin::Wrapper'),
+        resolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual({ inner: null })
+    })
+
+    it('should handle struct with vector field', async () => {
+      const resolver = createMockResolver({
+        Pool: [{ name: 'amounts', type: 'vector<u64>' }],
+      })
+
+      const result = await convertResourceValue(
+        { amounts: ['100', '200'] },
+        parseMoveType('0x1::pool::Pool'),
+        resolver,
+        emptyOpaqueTypes
+      )
+      expect(result).toEqual({ amounts: [100n, 200n] })
+    })
+
+    it('should handle null value', async () => {
+      const result = await convertResourceValue(
+        null,
+        parseMoveType('u64'),
+        emptyResolver,
+        emptyOpaqueTypes
+      )
+      // null is not a string, convertJsonValue returns it as-is for u64
+      expect(result).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

-->

<!--
Please provide clear motivation for your patch and explain how it improves
initia user experience or initia developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of initia, if possible.
-->

<!--
Initia has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 2.0.0-rc.4

* **New Features**
  * Move resource and table entry queries now support automatic type conversion (e.g., u64 → bigint)
  * Added `opaqueTypes` configuration option to customize conversion behavior

* **Refactor**
  * Enhanced type safety with readonly field annotations for Move type structures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->