### PR TITLE
fix(token): pass type argument to fungible_asset view calls

### DIFF
--- a/src/token/fungible-asset.ts
+++ b/src/token/fungible-asset.ts
@@ -17,6 +17,8 @@ import type { TokenContract } from './types'
 
 type MoveClient = ConnectClient<typeof MoveQuery>
 
+const FA_METADATA_TYPE = '0x1::fungible_asset::Metadata'
+
 /**
  * Create a Move Fungible Asset TokenContract adapter.
  *
@@ -53,10 +55,10 @@ export function createFungibleAssetToken(
   return {
     async getInfo(): Promise<TokenInfo> {
       const [name, symbol, decimals, supply] = await Promise.all([
-        viewJSON('fungible_asset', 'name', [metadataAddress]),
-        viewJSON('fungible_asset', 'symbol', [metadataAddress]),
-        viewJSON('fungible_asset', 'decimals', [metadataAddress]),
-        viewJSON('fungible_asset', 'supply', [metadataAddress]),
+        viewJSON('fungible_asset', 'name', [metadataAddress], [FA_METADATA_TYPE]),
+        viewJSON('fungible_asset', 'symbol', [metadataAddress], [FA_METADATA_TYPE]),
+        viewJSON('fungible_asset', 'decimals', [metadataAddress], [FA_METADATA_TYPE]),
+        viewJSON('fungible_asset', 'supply', [metadataAddress], [FA_METADATA_TYPE]),
       ])
 
       return {
@@ -68,7 +70,12 @@ export function createFungibleAssetToken(
     },
 
     async balanceOf(owner: string): Promise<bigint> {
-      const result = await viewJSON('primary_fungible_store', 'balance', [owner, metadataAddress])
+      const result = await viewJSON(
+        'primary_fungible_store',
+        'balance',
+        [owner, metadataAddress],
+        [FA_METADATA_TYPE]
+      )
       return BigInt(result as string)
     },
 

--- a/test/unit/token/token-msgs.spec.ts
+++ b/test/unit/token/token-msgs.spec.ts
@@ -63,14 +63,44 @@ describe('token module message builders return Message instances', () => {
       expect(msg.toAny().typeUrl).toContain('MsgExecute')
     })
 
-    it('viewJSON should not crash with bigint-like args', async () => {
+    it('viewJSON should pass FA_METADATA_TYPE as typeArgs', async () => {
       const mockMoveClient = {
         viewJSON: vi.fn().mockResolvedValue({ data: '"1000000"' }),
       }
       const token = createFungibleAssetToken(mockMoveClient as any, '0x1::metadata::Metadata')
       const balance = await token.balanceOf('0xowner')
-      expect(mockMoveClient.viewJSON).toHaveBeenCalled()
       expect(balance).toBe(1000000n)
+      expect(mockMoveClient.viewJSON).toHaveBeenCalledWith({
+        address: '0x1',
+        moduleName: 'primary_fungible_store',
+        functionName: 'balance',
+        typeArgs: ['0x1::fungible_asset::Metadata'],
+        args: ['"0xowner"', '"0x1::metadata::Metadata"'],
+      })
+    })
+
+    it('getInfo should pass FA_METADATA_TYPE as typeArgs', async () => {
+      const responses = ['"TestToken"', '"TT"', '6', '"1000000"']
+      let callIndex = 0
+      const mockMoveClient = {
+        viewJSON: vi.fn().mockImplementation(() => {
+          return Promise.resolve({ data: responses[callIndex++] })
+        }),
+      }
+      const token = createFungibleAssetToken(mockMoveClient as any, '0xmeta')
+      const info = await token.getInfo()
+
+      expect(mockMoveClient.viewJSON).toHaveBeenCalledTimes(4)
+      for (const call of mockMoveClient.viewJSON.mock.calls) {
+        expect(call[0]).toEqual(
+          expect.objectContaining({ typeArgs: ['0x1::fungible_asset::Metadata'] })
+        )
+      }
+
+      expect(info.name).toBe('TestToken')
+      expect(info.symbol).toBe('TT')
+      expect(info.decimals).toBe(6)
+      expect(info.totalSupply).toBe(1000000n)
     })
   })
 })


### PR DESCRIPTION
- Pass `0x1::fungible_asset::Metadata` as type argument to all view calls (`name`, `symbol`, `decimals`, `supply`, `balance`) in `createFungibleAssetToken`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fungible asset metadata retrieval to ensure accurate data is loaded correctly.
  * Improved fungible asset balance queries to provide more reliable and accurate results.
  * Enhanced query reliability for fungible asset information across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->