### PR TITLE
feat: support Initia v1.4.5 compatibility in v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -441,7 +441,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@chain-registry/types": {
       "version": "2.0.178",
@@ -728,6 +729,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -753,29 +755,6 @@
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
         "@connectrpc/connect": "2.1.1"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2085,6 +2064,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2134,6 +2114,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2288,9 +2269,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2511,6 +2492,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3012,6 +2994,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3066,6 +3049,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4324,9 +4308,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -4402,9 +4386,9 @@
       "license": "MIT"
     },
     "node_modules/ox": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.7.tgz",
-      "integrity": "sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==",
+      "version": "0.14.22",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.22.tgz",
+      "integrity": "sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==",
       "funding": [
         {
           "type": "github",
@@ -4653,9 +4637,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -4673,7 +4657,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4856,6 +4840,7 @@
       "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.122.0",
         "@rolldown/pluginutils": "1.0.0-rc.12"
@@ -5416,6 +5401,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5548,9 +5534,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.47.6",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.6.tgz",
-      "integrity": "sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==",
+      "version": "2.50.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.50.4.tgz",
+      "integrity": "sha512-rf98F4s3Vlb+uJZEKfay3IbBw3CNCbVtx5Y3UIljlO2tSX420g/J0WQSYsjzBSasUFgxgsXabji14O9kGbiqgg==",
       "funding": [
         {
           "type": "github",
@@ -5565,8 +5551,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.7",
-        "ws": "8.18.3"
+        "ox": "0.14.22",
+        "ws": "8.20.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -5646,6 +5632,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5821,9 +5808,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5841,9 +5825,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5861,9 +5842,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5881,9 +5859,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5901,9 +5876,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5921,9 +5893,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6248,10 +6217,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/src/chain-config.ts
+++ b/src/chain-config.ts
@@ -126,6 +126,7 @@ export class ChainConfigBuilder<
 > {
   private modules: Record<string, ModuleInput> = {}
   private typeInputs: TypeInput[] = []
+  private decodeSchemas: DescMessage[] = []
 
   addModule<K extends string, M extends ModuleInput>(
     name: K,
@@ -147,6 +148,12 @@ export class ChainConfigBuilder<
   addTypes(...inputs: TypeInput[]): ChainConfigBuilder<TDefault> {
     const next = this.clone()
     next.typeInputs.push(...inputs)
+    return next
+  }
+
+  addDecodeTypes(...schemas: DescMessage[]): ChainConfigBuilder<TDefault> {
+    const next = this.clone()
+    next.decodeSchemas.push(...schemas)
     return next
   }
 
@@ -173,12 +180,13 @@ export class ChainConfigBuilder<
     for (const mod of Object.values(this.modules)) {
       if (mod.tx) allSchemas.push(...extractSchemas(mod.tx))
     }
+    allSchemas.push(...this.decodeSchemas)
 
     // decode: resolves Any by typeUrl using schemas from registered modules
     // registry: resolves types from typeInputs (accumulated via addModule + addTypes),
     //           additionally contains non-module types from addTypes() (e.g., crypto keys, auth)
     const decode = createDecode(allSchemas)
-    const registry = createRegistry(...this.typeInputs)
+    const registry = createRegistry(...this.typeInputs, ...this.decodeSchemas)
 
     const msgs = {
       ...msgBuilders,
@@ -194,6 +202,7 @@ export class ChainConfigBuilder<
     const next = new ChainConfigBuilder<TDefault>()
     next.modules = { ...this.modules }
     next.typeInputs = [...this.typeInputs]
+    next.decodeSchemas = [...this.decodeSchemas]
     return next
   }
 }

--- a/src/chains/initia.ts
+++ b/src/chains/initia.ts
@@ -14,7 +14,11 @@ import { Query as PermQuery } from '@buf/initia-labs_initia.bufbuild_es/ibc/appl
 import { Query as InitiaTxQuery } from '@buf/initia-labs_initia.bufbuild_es/initia/tx/v1/query_pb'
 
 // Tx services — full modules (query + tx)
-import { Msg as MoveTxMsg } from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/tx_pb'
+import {
+  Msg as MoveTxMsg,
+  MsgWhitelistSchema,
+  MsgDelistSchema,
+} from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/tx_pb'
 import { Msg as MstakingTxMsg } from '@buf/initia-labs_initia.bufbuild_es/initia/mstaking/v1/tx_pb'
 import { Msg as DistributionTxMsg } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/distribution/v1beta1/tx_pb'
 import { Msg as GovTxMsg } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/gov/v1/tx_pb'
@@ -52,4 +56,5 @@ export const initiaChain = createBaseConfig()
   .addModule('nftTransfer', { query: NftTransferQuery, tx: NftTransferTxMsg })
   .addModule('perm', { query: PermQuery, tx: PermTxMsg })
   .addModule('initiaTx', { query: InitiaTxQuery })
+  .addDecodeTypes(MsgWhitelistSchema, MsgDelistSchema)
   .addTypes(file_initia_move_v1_auth)

--- a/src/client/gas.ts
+++ b/src/client/gas.ts
@@ -3,6 +3,8 @@
  */
 
 import { create } from '@bufbuild/protobuf'
+import type { Any } from '@bufbuild/protobuf/wkt'
+import type { Numeric } from '../types'
 import { type MsgInput, normalizeMsg } from '../msgs/types'
 import {
   TxSchema,
@@ -36,6 +38,12 @@ export interface EstimateOptions {
   multiplier?: number
   /** Gas price (e.g., '0.015uinit') */
   gasPrice?: string
+  /** Timeout block height for simulated TxBody (0 or undefined = no timeout) */
+  timeoutHeight?: Numeric
+  /** Cosmos TxBody extension options for simulation */
+  extensionOptions?: Any[]
+  /** Cosmos TxBody non-critical extension options for simulation */
+  nonCriticalExtensionOptions?: Any[]
 }
 
 /**
@@ -145,9 +153,9 @@ export async function estimateGas(
   const txBody = create(TxBodySchema, {
     messages: msgs.map(m => normalizeMsg(m).toAny()),
     memo: '',
-    timeoutHeight: 0n,
-    extensionOptions: [],
-    nonCriticalExtensionOptions: [],
+    timeoutHeight: BigInt(options?.timeoutHeight ?? 0),
+    extensionOptions: options?.extensionOptions ?? [],
+    nonCriticalExtensionOptions: options?.nonCriticalExtensionOptions ?? [],
   })
 
   // Create minimal auth info (empty signature is ok for simulation)

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -5,6 +5,7 @@
 import type { QueryClient } from './grpc-client'
 import type { Numeric } from '../types'
 import type { CoinLike } from '../core/coin'
+import type { Any } from '@bufbuild/protobuf/wkt'
 
 // Derived client types (computed from chain config builders)
 export type {
@@ -214,6 +215,12 @@ export interface TxOptions {
   gasLimit?: Numeric
   /** Optional memo to include */
   memo?: string
+  /** Timeout block height (0 or undefined = no timeout) */
+  timeoutHeight?: Numeric
+  /** Cosmos TxBody extension options */
+  extensionOptions?: Any[]
+  /** Cosmos TxBody non-critical extension options */
+  nonCriticalExtensionOptions?: Any[]
   /** Signing mode (default: 'direct') */
   signMode?: SignModeType
 }

--- a/src/entry.tx.ts
+++ b/src/entry.tx.ts
@@ -1,4 +1,5 @@
 export * from './tx/sign'
+export { ExtensionOptionQueuedTx } from './tx/extension-options'
 
 export {
   toAmino,

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export type {
 export { createSignedTx, makeStdSignDoc, makeAminoSignBytes, buildStdFee } from './tx/sign'
 export { UnsignedTx } from './tx/unsigned-tx'
 export type { MultisigSignature } from './tx/unsigned-tx'
+export { ExtensionOptionQueuedTx } from './tx/extension-options'
 
 // =============================================================================
 // Key Management

--- a/src/key/key.ts
+++ b/src/key/key.ts
@@ -141,7 +141,8 @@ export abstract class Key implements OfflineSigner {
           tx.chainId,
           tx.memo,
           tx.accountNumber,
-          tx.sequence
+          tx.sequence,
+          tx.timeoutHeight
         )
         const signBytes =
           tx.signMode === 'eip191'

--- a/src/signer/types.ts
+++ b/src/signer/types.ts
@@ -149,6 +149,7 @@ export interface AminoSignDoc {
   fee: AminoFee
   msgs: AminoMsg[]
   memo: string
+  timeout_height?: string
 }
 
 /**

--- a/src/tx/extension-options.ts
+++ b/src/tx/extension-options.ts
@@ -1,0 +1,12 @@
+import { create } from '@bufbuild/protobuf'
+import type { Any } from '@bufbuild/protobuf/wkt'
+import { ExtensionOptionQueuedTxSchema } from '@buf/initia-labs_initia.bufbuild_es/initia/tx/v1/tx_pb'
+import { anyPack } from '../util/any'
+
+export const ExtensionOptionQueuedTx = {
+  TYPE_URL: '/initia.tx.v1.ExtensionOptionQueuedTx',
+
+  packAny(): Any {
+    return anyPack(ExtensionOptionQueuedTxSchema, create(ExtensionOptionQueuedTxSchema, {}))
+  },
+} as const

--- a/src/tx/index.ts
+++ b/src/tx/index.ts
@@ -18,6 +18,8 @@ export {
   encodeTxDirect,
 } from './sign'
 
+export { ExtensionOptionQueuedTx } from './extension-options'
+
 // EVM transaction utilities
 export { sendEvmTx, sendEvmTxAndWait, type SendEvmTxOptions, type EvmTxResult } from './evm'
 

--- a/src/tx/sign.ts
+++ b/src/tx/sign.ts
@@ -152,6 +152,7 @@ export interface StdSignDoc {
   memo: string
   msgs: AminoMsg[]
   sequence: string
+  timeout_height?: string
 }
 
 /**
@@ -163,6 +164,7 @@ export interface StdSignDoc {
  * @param memo - Transaction memo
  * @param accountNumber - Account number
  * @param sequence - Account sequence
+ * @param timeoutHeight - Optional timeout block height
  * @returns StdSignDoc ready for canonical JSON serialization
  */
 export function makeStdSignDoc(
@@ -171,8 +173,10 @@ export function makeStdSignDoc(
   chainId: string,
   memo: string,
   accountNumber: Numeric,
-  sequence: Numeric
+  sequence: Numeric,
+  timeoutHeight?: Numeric
 ): StdSignDoc {
+  const normalizedTimeoutHeight = BigInt(timeoutHeight ?? 0)
   return {
     account_number: accountNumber.toString(),
     chain_id: chainId,
@@ -180,6 +184,9 @@ export function makeStdSignDoc(
     memo,
     msgs,
     sequence: sequence.toString(),
+    ...(normalizedTimeoutHeight !== 0n
+      ? { timeout_height: normalizedTimeoutHeight.toString() }
+      : {}),
   }
 }
 
@@ -250,6 +257,8 @@ export function encodeTxDirect(
     messages: tx.msgs.map(m => m.toAny()),
     memo: tx.memo,
     timeoutHeight: tx.timeoutHeight,
+    extensionOptions: tx.extensionOptions,
+    nonCriticalExtensionOptions: tx.nonCriticalExtensionOptions,
   })
   const bodyBytes = toBinary(TxBodySchema, txBody)
 

--- a/src/tx/unsigned-tx.ts
+++ b/src/tx/unsigned-tx.ts
@@ -12,6 +12,7 @@ import { MultiSignature } from '../key/multisig'
 import { createSignedTx, makeSignBytes } from './sign'
 import { Coin } from '../core/coin'
 import type { CoinLike } from '../core/coin'
+import type { Any } from '@bufbuild/protobuf/wkt'
 import { create, toBinary } from '@bufbuild/protobuf'
 import {
   TxBodySchema,
@@ -69,6 +70,10 @@ export class UnsignedTx {
   readonly memo: string
   /** Timeout block height (0 = no timeout) */
   readonly timeoutHeight: bigint
+  /** Cosmos TxBody extension options */
+  readonly extensionOptions: Any[]
+  /** Cosmos TxBody non-critical extension options */
+  readonly nonCriticalExtensionOptions: Any[]
 
   constructor(data: {
     msgs: Message[]
@@ -80,16 +85,20 @@ export class UnsignedTx {
     gasLimit: bigint
     memo: string
     timeoutHeight?: bigint
+    extensionOptions?: Any[]
+    nonCriticalExtensionOptions?: Any[]
   }) {
     this.msgs = data.msgs
     this.signMode = data.signMode
     this.chainId = data.chainId
     this.accountNumber = data.accountNumber
     this.sequence = data.sequence
-    this.fee = data.fee.map(c => c instanceof Coin ? c : new Coin(c.denom, c.amount))
+    this.fee = data.fee.map(c => (c instanceof Coin ? c : new Coin(c.denom, c.amount)))
     this.gasLimit = data.gasLimit
     this.memo = data.memo
     this.timeoutHeight = data.timeoutHeight ?? 0n
+    this.extensionOptions = [...(data.extensionOptions ?? [])]
+    this.nonCriticalExtensionOptions = [...(data.nonCriticalExtensionOptions ?? [])]
   }
 
   /**
@@ -149,6 +158,8 @@ export class UnsignedTx {
       messages: this.msgs.map(m => m.toAny()),
       memo: this.memo,
       timeoutHeight: this.timeoutHeight,
+      extensionOptions: this.extensionOptions,
+      nonCriticalExtensionOptions: this.nonCriticalExtensionOptions,
     })
   }
 

--- a/src/wallet/chain-context.ts
+++ b/src/wallet/chain-context.ts
@@ -173,7 +173,7 @@ export type TokenResolver = (
 export type ContractResolver = (...args: any[]) => any
 
 /** Wrap a VM-specific contract factory as a ContractResolver with a chainType guard. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 export function createContractResolver(
   expectedChainType: string,
   factory: (...args: any[]) => any
@@ -880,6 +880,9 @@ class ChainContextImpl<
       fee: options?.fee ?? [],
       gasLimit: BigInt(options?.gasLimit ?? DEFAULT_GAS_LIMIT),
       memo: options?.memo ?? '',
+      timeoutHeight: BigInt(options?.timeoutHeight ?? 0),
+      extensionOptions: options?.extensionOptions ?? [],
+      nonCriticalExtensionOptions: options?.nonCriticalExtensionOptions ?? [],
     })
   }
 
@@ -966,6 +969,7 @@ class ChainContextImpl<
       fee: buildStdFee(tx),
       msgs: aminoMsgs,
       memo: tx.memo,
+      ...(tx.timeoutHeight !== 0n ? { timeout_height: tx.timeoutHeight.toString() } : {}),
     }
 
     const response = await signer.signAmino(address, aminoSignDoc)
@@ -975,9 +979,9 @@ class ChainContextImpl<
     const txBody = create(TxBodySchema, {
       messages: tx.msgs.map(m => m.toAny()),
       memo: signed.memo,
-      timeoutHeight: 0n,
-      extensionOptions: [],
-      nonCriticalExtensionOptions: [],
+      timeoutHeight: BigInt(signed.timeout_height ?? tx.timeoutHeight),
+      extensionOptions: tx.extensionOptions,
+      nonCriticalExtensionOptions: tx.nonCriticalExtensionOptions,
     })
     const bodyBytes = toBinary(TxBodySchema, txBody)
 
@@ -1027,7 +1031,8 @@ class ChainContextImpl<
       tx.chainId,
       tx.memo,
       tx.accountNumber,
-      tx.sequence
+      tx.sequence,
+      tx.timeoutHeight
     )
     const aminoBytes = makeAminoSignBytes(stdSignDoc)
     const signature = await (signer as EIP191Signer).signPersonal(aminoBytes)
@@ -1083,6 +1088,9 @@ class ChainContextImpl<
         gasPrice: options?.gasPrice ?? this.chainInfo.gasPrice,
         multiplier: options?.gasMultiplier,
         signer: options?.signer,
+        timeoutHeight: options?.timeoutHeight,
+        extensionOptions: options?.extensionOptions,
+        nonCriticalExtensionOptions: options?.nonCriticalExtensionOptions,
       })
       txOptions = {
         ...options,

--- a/test/e2e/bridge.spec.ts
+++ b/test/e2e/bridge.spec.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest'
+import { Code, ConnectError } from '@connectrpc/connect'
 import { createRegistryProvider } from '../../src/provider/registry-provider'
 import { createTransport, createChainContext } from '../../src/entry.node'
 import { MnemonicKey } from '../../src/key/mnemonic-key'
@@ -61,6 +62,37 @@ function skipInfra(condition: boolean, reason: string): boolean {
   return true
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isNetworkInfraError(error: unknown): boolean {
+  if (error instanceof ConnectError) {
+    return error.code === Code.Unavailable || error.code === Code.DeadlineExceeded
+  }
+
+  return /ETIMEDOUT|EHOSTUNREACH|ECONNRESET|ECONNREFUSED|ENOTFOUND|fetch failed|timeout/i.test(
+    errorMessage(error)
+  )
+}
+
+function skipNetworkInfra(error: unknown, context: string): boolean {
+  if (!isNetworkInfraError(error)) throw error
+  return skipInfra(false, `${context}: ${errorMessage(error)}`)
+}
+
+function isBridgeStateInfraFailure(rawLog: string): boolean {
+  return /burn amount exceeds balance|insufficient funds|insufficient balance|balance insufficient/i.test(
+    rawLog
+  )
+}
+
+function skipBridgeStateInfra(result: { code: number; rawLog: string }, context: string): boolean {
+  if (result.code === 0) return false
+  if (!isBridgeStateInfraFailure(result.rawLog)) return false
+  return skipInfra(false, `${context}: code=${result.code} log=${result.rawLog}`)
+}
+
 // ---------------------------------------------------------------------------
 // Asset info (populated during beforeAll)
 // ---------------------------------------------------------------------------
@@ -91,22 +123,35 @@ async function waitForBalance(chainId: string, asset: AssetInfo, needed: bigint)
   const ctx = createChainContext(_provider.getChainInfo(chainId)!)
 
   while (Date.now() - start < maxWait) {
-    const balances = await ctx.getBalance({ denom: asset.denom, address: _key.address })
-    const balance = balances.length > 0 ? BigInt(balances[0].amount) : 0n
-    if (balance >= needed) {
+    try {
+      const balances = await ctx.getBalance({ denom: asset.denom, address: _key.address })
+      const balance = balances.length > 0 ? BigInt(balances[0].amount) : 0n
+      if (balance >= needed) {
+        log(
+          `[${chainId}] Balance ready: ${balance} (waited ${((Date.now() - start) / 1000).toFixed(0)}s)`
+        )
+        return balance
+      }
       log(
-        `[${chainId}] Balance ready: ${balance} (waited ${((Date.now() - start) / 1000).toFixed(0)}s)`
+        `[${chainId}] Waiting for balance... ${balance}/${needed} (${((Date.now() - start) / 1000).toFixed(0)}s)`
       )
-      return balance
+    } catch (err) {
+      if (!isNetworkInfraError(err)) throw err
+      log(
+        `[${chainId}] Waiting for balance... network error: ${errorMessage(err)} (${((Date.now() - start) / 1000).toFixed(0)}s)`
+      )
     }
-    log(
-      `[${chainId}] Waiting for balance... ${balance}/${needed} (${((Date.now() - start) / 1000).toFixed(0)}s)`
-    )
     await new Promise(r => setTimeout(r, pollInterval))
   }
 
-  const balances = await ctx.getBalance({ denom: asset.denom, address: _key.address })
-  return balances.length > 0 ? BigInt(balances[0].amount) : 0n
+  try {
+    const balances = await ctx.getBalance({ denom: asset.denom, address: _key.address })
+    return balances.length > 0 ? BigInt(balances[0].amount) : 0n
+  } catch (err) {
+    if (!isNetworkInfraError(err)) throw err
+    log(`[${chainId}] Final balance query failed: ${errorMessage(err)}`)
+    return 0n
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -147,6 +192,7 @@ describe.skipIf(SKIP)('Router E2E: L1 → move-1 → evm-1 → L1', () => {
   describe('Step 1: L1 → move-1', () => {
     let route: Route
     let txs: TransferTx[]
+    let l1BalanceReady = false
 
     it('should have sufficient L1 balance', async () => {
       const l1 = createChainContext(provider.getChainInfo(L1)!, { signer: key })
@@ -155,6 +201,7 @@ describe.skipIf(SKIP)('Router E2E: L1 → move-1 → evm-1 → L1', () => {
       const needed = BigInt(toAmount(TEST_HUMAN_AMOUNT * 3, L1_ASSET))
       log(`L1 balance: ${balance} ${L1_ASSET.denom}`)
       if (skipInfra(balance > needed, `L1 balance insufficient (need ${needed})`)) return
+      l1BalanceReady = true
       expect(balance).toBeGreaterThan(0n)
     }, 30_000)
 
@@ -174,6 +221,7 @@ describe.skipIf(SKIP)('Router E2E: L1 → move-1 → evm-1 → L1', () => {
     }, 30_000)
 
     it('should build and broadcast L1 → move-1 tx', async () => {
+      if (skipInfra(l1BalanceReady, 'L1 balance not ready')) return
       if (skipUnless(!!route, 'no route')) return
       txs = await provider.bridge.buildTransferMsgs({
         route,
@@ -187,10 +235,16 @@ describe.skipIf(SKIP)('Router E2E: L1 → move-1 → evm-1 → L1', () => {
       if (skipUnless(!!cosmosTx, 'no cosmos msgs in built txs')) return
 
       const ctx = createChainContext(provider.getChainInfo(cosmosTx!.chainId)!, { signer: key })
-      const result = await ctx.signAndBroadcast(cosmosTx!.cosmosMsgs!, {
-        waitForConfirmation: true,
-      })
+      let result
+      try {
+        result = await ctx.signAndBroadcast(cosmosTx!.cosmosMsgs!, {
+          waitForConfirmation: true,
+        })
+      } catch (err) {
+        if (skipNetworkInfra(err, 'L1 → move-1 broadcast failed')) return
+      }
       log(`Tx: ${result.txHash} code=${result.code} gas=${result.gasUsed}`)
+      if (skipBridgeStateInfra(result, 'L1 → move-1 tx failed on-chain')) return
       expect(result.code).toBe(0)
     }, 120_000)
   })
@@ -202,15 +256,17 @@ describe.skipIf(SKIP)('Router E2E: L1 → move-1 → evm-1 → L1', () => {
   describe('Step 2: move-1 → evm-1', () => {
     let route: Route
     let txs: TransferTx[]
+    let moveBalanceReady = false
 
     it('should wait for move-1 balance', async () => {
       if (skipUnless(!!MOVE_ASSET.denom, 'move-1 denom not discovered')) return
       const needed = BigInt(toAmount(TEST_HUMAN_AMOUNT, MOVE_ASSET))
       const balance = await waitForBalance(MOVE_L2, MOVE_ASSET, needed)
       if (
-        skipUnless(balance >= needed, `move-1 balance insufficient after polling (need ${needed})`)
+        skipInfra(balance >= needed, `move-1 balance insufficient after polling (need ${needed})`)
       )
         return
+      moveBalanceReady = true
       expect(balance).toBeGreaterThanOrEqual(needed)
     }, 120_000)
 
@@ -230,6 +286,7 @@ describe.skipIf(SKIP)('Router E2E: L1 → move-1 → evm-1 → L1', () => {
     }, 30_000)
 
     it('should build and broadcast move-1 → evm-1 tx', async () => {
+      if (skipInfra(moveBalanceReady, 'move-1 balance not ready')) return
       if (skipUnless(!!route, 'no route')) return
       txs = await provider.bridge.buildTransferMsgs({
         route,
@@ -243,10 +300,16 @@ describe.skipIf(SKIP)('Router E2E: L1 → move-1 → evm-1 → L1', () => {
       if (skipUnless(!!cosmosTx, 'no cosmos msgs in built txs')) return
 
       const ctx = createChainContext(provider.getChainInfo(cosmosTx!.chainId)!, { signer: key })
-      const result = await ctx.signAndBroadcast(cosmosTx!.cosmosMsgs!, {
-        waitForConfirmation: true,
-      })
+      let result
+      try {
+        result = await ctx.signAndBroadcast(cosmosTx!.cosmosMsgs!, {
+          waitForConfirmation: true,
+        })
+      } catch (err) {
+        if (skipNetworkInfra(err, 'move-1 → evm-1 broadcast failed')) return
+      }
       log(`Tx: ${result.txHash} code=${result.code} gas=${result.gasUsed}`)
+      if (skipBridgeStateInfra(result, 'move-1 → evm-1 tx failed on-chain')) return
       expect(result.code).toBe(0)
     }, 120_000)
   })
@@ -258,15 +321,15 @@ describe.skipIf(SKIP)('Router E2E: L1 → move-1 → evm-1 → L1', () => {
   describe('Step 3: evm-1 → L1', () => {
     let route: Route
     let txs: TransferTx[]
+    let evmBalanceReady = false
 
     it('should wait for evm-1 balance', async () => {
       if (skipUnless(!!EVM_ASSET.denom, 'evm-1 denom not discovered')) return
       const needed = BigInt(toAmount(TEST_HUMAN_AMOUNT, EVM_ASSET))
       const balance = await waitForBalance(EVM_L2, EVM_ASSET, needed)
-      if (
-        skipUnless(balance >= needed, `evm-1 balance insufficient after polling (need ${needed})`)
-      )
+      if (skipInfra(balance >= needed, `evm-1 balance insufficient after polling (need ${needed})`))
         return
+      evmBalanceReady = true
       expect(balance).toBeGreaterThanOrEqual(needed)
     }, 120_000)
 
@@ -286,6 +349,7 @@ describe.skipIf(SKIP)('Router E2E: L1 → move-1 → evm-1 → L1', () => {
     }, 30_000)
 
     it('should build and broadcast evm-1 → L1 tx', async () => {
+      if (skipInfra(evmBalanceReady, 'evm-1 balance not ready')) return
       if (skipUnless(!!route, 'no route')) return
       txs = await provider.bridge.buildTransferMsgs({
         route,
@@ -299,10 +363,16 @@ describe.skipIf(SKIP)('Router E2E: L1 → move-1 → evm-1 → L1', () => {
       if (skipUnless(!!cosmosTx, 'no cosmos msgs in built txs')) return
 
       const ctx = createChainContext(provider.getChainInfo(cosmosTx!.chainId)!, { signer: key })
-      const result = await ctx.signAndBroadcast(cosmosTx!.cosmosMsgs!, {
-        waitForConfirmation: true,
-      })
+      let result
+      try {
+        result = await ctx.signAndBroadcast(cosmosTx!.cosmosMsgs!, {
+          waitForConfirmation: true,
+        })
+      } catch (err) {
+        if (skipNetworkInfra(err, 'evm-1 → L1 broadcast failed')) return
+      }
       log(`Tx: ${result.txHash} code=${result.code} gas=${result.gasUsed}`)
+      if (skipBridgeStateInfra(result, 'evm-1 → L1 tx failed on-chain')) return
       expect(result.code).toBe(0)
     }, 120_000)
   })

--- a/test/e2e/l2.spec.ts
+++ b/test/e2e/l2.spec.ts
@@ -18,6 +18,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest'
+import { Code, ConnectError } from '@connectrpc/connect'
 import { createChainContext, createTransport } from '../../src/entry.node'
 import { createRegistryProvider } from '../../src/provider/registry-provider'
 import { MnemonicKey } from '../../src/key/mnemonic-key'
@@ -194,6 +195,20 @@ function skipInfra(condition: boolean, reason: string): boolean {
   if (condition) return false
   log(`SKIP (infra): ${reason}`)
   return true
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isNetworkInfraError(error: unknown): boolean {
+  if (error instanceof ConnectError) {
+    return error.code === Code.Unavailable || error.code === Code.DeadlineExceeded
+  }
+
+  return /ETIMEDOUT|EHOSTUNREACH|ECONNRESET|ECONNREFUSED|ENOTFOUND|fetch failed|timeout/i.test(
+    errorMessage(error)
+  )
 }
 
 /**
@@ -379,31 +394,46 @@ describe.skipIf(SKIP)('L2 E2E: Deposit -> Transact -> Withdraw', () => {
         const start = Date.now()
 
         while (Date.now() - start < maxWait) {
-          // Discover L2 native denom and check balance in one step
-          const denom = await discoverL2NativeDenom(wallet, l2)
-          if (denom) {
-            const balance = await queryBalance(wallet, l2)
-            if (balance >= DEPOSIT_AMOUNT) {
+          try {
+            // Discover L2 native denom and check balance in one step
+            const denom = await discoverL2NativeDenom(wallet, l2)
+            if (denom) {
+              const balance = await queryBalance(wallet, l2)
+              if (balance >= DEPOSIT_AMOUNT) {
+                log(
+                  `[${l2}] Deposit arrived: ${fmtInit(balance)} denom=${denom} (waited ${((Date.now() - start) / 1000).toFixed(0)}s)`
+                )
+                return
+              }
               log(
-                `[${l2}] Deposit arrived: ${fmtInit(balance)} denom=${denom} (waited ${((Date.now() - start) / 1000).toFixed(0)}s)`
+                `[${l2}] Waiting... balance=${fmtInit(balance)} denom=${denom} (${((Date.now() - start) / 1000).toFixed(0)}s)`
               )
-              return
+            } else {
+              log(
+                `[${l2}] Waiting... no l2/ denom yet (${((Date.now() - start) / 1000).toFixed(0)}s)`
+              )
             }
+          } catch (err) {
+            if (!isNetworkInfraError(err)) throw err
             log(
-              `[${l2}] Waiting... balance=${fmtInit(balance)} denom=${denom} (${((Date.now() - start) / 1000).toFixed(0)}s)`
-            )
-          } else {
-            log(
-              `[${l2}] Waiting... no l2/ denom yet (${((Date.now() - start) / 1000).toFixed(0)}s)`
+              `[${l2}] Waiting... network error: ${errorMessage(err)} (${((Date.now() - start) / 1000).toFixed(0)}s)`
             )
           }
           await new Promise(r => setTimeout(r, pollInterval))
         }
 
         const finalDenom = getNativeDenom(l2)
-        const finalBalance = await queryBalance(wallet, l2)
+        let finalBalance: bigint
+        try {
+          finalBalance = await queryBalance(wallet, l2)
+        } catch (err) {
+          if (!isNetworkInfraError(err)) throw err
+          if (skipInfra(false, `[${l2}] deposit polling network error: ${errorMessage(err)}`))
+            return
+          throw err
+        }
         if (
-          skipUnless(
+          skipInfra(
             finalBalance >= DEPOSIT_AMOUNT,
             `[${l2}] deposit not arrived after ${maxWait / 1000}s (balance: ${fmtInit(finalBalance)} denom=${finalDenom})`
           )
@@ -571,8 +601,9 @@ describe.skipIf(SKIP)('L2 E2E: Deposit -> Transact -> Withdraw', () => {
         const erc20 = createEvmContract(ctx, EVM_ERC20_ADDRESS, ERC20_ABI)
         const sender = await wallet.getAddress('evm-1')
 
-        const balanceBefore = await erc20.read.balanceOf(senderEvmAddress as `0x${string}`)
-        if (skipInfra(balanceBefore > 0n, '[evm-1] sender has no ERC20 balance for transfer test'))
+        const senderBefore = await erc20.read.balanceOf(senderEvmAddress as `0x${string}`)
+        const recipientBefore = await erc20.read.balanceOf(recipientEvmAddress as `0x${string}`)
+        if (skipInfra(senderBefore > 0n, '[evm-1] sender has no ERC20 balance for transfer test'))
           return
 
         const transferAmount = 1n
@@ -588,14 +619,22 @@ describe.skipIf(SKIP)('L2 E2E: Deposit -> Transact -> Withdraw', () => {
         expect(result.txHash).toHaveLength(64)
         expect(result.gasUsed).toBeGreaterThan(0n)
 
-        const balanceAfter = await erc20.read.balanceOf(senderEvmAddress as `0x${string}`)
-        expect(balanceBefore - balanceAfter).toBe(transferAmount)
+        const senderAfter = await erc20.read.balanceOf(senderEvmAddress as `0x${string}`)
+        const recipientAfter = await erc20.read.balanceOf(recipientEvmAddress as `0x${string}`)
+        const senderDiff = senderBefore - senderAfter
+        const recipientDiff = recipientAfter - recipientBefore
+
+        expect(recipientDiff).toBe(transferAmount)
+        expect(senderDiff).toBeGreaterThanOrEqual(transferAmount)
 
         log(
           `[evm-1] ERC20 transfer: ${result.txHash} height=${result.height} gasUsed=${result.gasUsed}`
         )
         log(
-          `[evm-1]   balance change: ${balanceBefore} -> ${balanceAfter} (diff: ${balanceBefore - balanceAfter})`
+          `[evm-1]   sender balance change: ${senderBefore} -> ${senderAfter} (diff: ${senderDiff})`
+        )
+        log(
+          `[evm-1]   recipient balance change: ${recipientBefore} -> ${recipientAfter} (diff: ${recipientDiff})`
         )
       }, 120_000)
     })

--- a/test/type-tests/chain-config.spec.ts
+++ b/test/type-tests/chain-config.spec.ts
@@ -3,7 +3,11 @@ import { createChainConfig } from '../../src/chain-config'
 import { Msg as BankTxMsg } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/bank/v1beta1/tx_pb'
 import { Query as BankQuery } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/bank/v1beta1/query_pb'
 import { Query as AuthQuery } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/auth/v1beta1/query_pb'
-import { Msg as MoveTxMsg } from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/tx_pb'
+import {
+  Msg as MoveTxMsg,
+  MsgWhitelistSchema,
+  MsgDelistSchema,
+} from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/tx_pb'
 
 test('ChainConfigBuilder type inference', () => {
   const config = createChainConfig()
@@ -31,4 +35,15 @@ test('ChainConfigBuilder type inference', () => {
   // custom and decode always present
   expectTypeOf(config.msgs.custom).toBeFunction()
   expectTypeOf(config.msgs.decode).toBeFunction()
+})
+
+test('addDecodeTypes preserves module type inference without adding builders', () => {
+  const config = createChainConfig()
+    .addModule('move', { tx: MoveTxMsg })
+    .addDecodeTypes(MsgWhitelistSchema, MsgDelistSchema)
+    .build()
+
+  expectTypeOf(config.msgs.move.execute).toBeFunction()
+  expectTypeOf(config.msgs.move).not.toHaveProperty('whitelist')
+  expectTypeOf(config.msgs.move).not.toHaveProperty('delist')
 })

--- a/test/unit/chain-config.spec.ts
+++ b/test/unit/chain-config.spec.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect } from 'vitest'
+import { create } from '@bufbuild/protobuf'
 import { createChainConfig } from '../../src/chain-config'
 import { Msg as BankTxMsg } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/bank/v1beta1/tx_pb'
 import { Query as BankQuery } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/bank/v1beta1/query_pb'
 import { Query as AuthQuery } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/auth/v1beta1/query_pb'
-import { Msg as MoveTxMsg } from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/tx_pb'
+import {
+  Msg as MoveTxMsg,
+  MsgWhitelistSchema,
+  MsgDelistSchema,
+} from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/tx_pb'
 import { file_cosmos_crypto_ed25519_keys } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/crypto/ed25519/keys_pb'
 import { Msg as ChannelTxMsg } from '@buf/cosmos_ibc.bufbuild_es/ibc/core/channel/v1/tx_pb'
 import { Msg as ClientTxMsg } from '@buf/cosmos_ibc.bufbuild_es/ibc/core/client/v1/tx_pb'
@@ -12,6 +17,7 @@ import { Query as IbcChannelQuery } from '@buf/cosmos_ibc.bufbuild_es/ibc/core/c
 import { Query as IbcClientQuery } from '@buf/cosmos_ibc.bufbuild_es/ibc/core/client/v1/query_pb'
 import { Query as AuthzQuery } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/authz/v1beta1/query_pb'
 import { coin } from '../../src/core/coin'
+import { anyPack } from '../../src/util/any'
 
 describe('createChainConfig', () => {
   it('returns a ChainConfigBuilder', () => {
@@ -137,6 +143,52 @@ describe('addTypes', () => {
 
     const desc = config.registry.getMessage('cosmos.crypto.ed25519.PubKey')
     expect(desc).toBeDefined()
+  })
+})
+
+describe('addDecodeTypes', () => {
+  it('allows decode-only schemas without module builders', () => {
+    const config = createChainConfig().addDecodeTypes(MsgWhitelistSchema, MsgDelistSchema).build()
+
+    const whitelist = create(MsgWhitelistSchema, {
+      authority: 'init1authority',
+      metadataLp: 'lptoken',
+      rewardWeight: '0.5',
+    })
+    const delist = create(MsgDelistSchema, {
+      authority: 'init1authority',
+      metadataLp: 'lptoken',
+    })
+
+    expect(config.msgs.decode(anyPack(MsgWhitelistSchema, whitelist)).typeUrl).toBe(
+      '/initia.move.v1.MsgWhitelist'
+    )
+    expect(config.msgs.decode(anyPack(MsgDelistSchema, delist)).typeUrl).toBe(
+      '/initia.move.v1.MsgDelist'
+    )
+    expect((config.msgs as unknown as Record<string, unknown>).move).toBeUndefined()
+  })
+
+  it('returns a new builder without mutating the original builder', () => {
+    const base = createChainConfig()
+    const withDecode = base.addDecodeTypes(MsgWhitelistSchema)
+    const value = create(MsgWhitelistSchema, {
+      authority: 'init1authority',
+      metadataLp: 'lptoken',
+      rewardWeight: '0.5',
+    })
+
+    expect(() => base.build().msgs.decode(anyPack(MsgWhitelistSchema, value))).toThrow()
+    expect(withDecode.build().msgs.decode(anyPack(MsgWhitelistSchema, value)).typeUrl).toBe(
+      '/initia.move.v1.MsgWhitelist'
+    )
+  })
+
+  it('registers decode-only schemas in the registry', () => {
+    const config = createChainConfig().addDecodeTypes(MsgWhitelistSchema, MsgDelistSchema).build()
+
+    expect(config.registry.getMessage('initia.move.v1.MsgWhitelist')).toBeDefined()
+    expect(config.registry.getMessage('initia.move.v1.MsgDelist')).toBeDefined()
   })
 })
 

--- a/test/unit/chain-configs.spec.ts
+++ b/test/unit/chain-configs.spec.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect } from 'vitest'
+import { create } from '@bufbuild/protobuf'
 import { initiaChain } from '../../src/chains/initia'
 import { minievmChain } from '../../src/chains/minievm'
 import { minimoveChain } from '../../src/chains/minimove'
 import { miniwasmChain } from '../../src/chains/miniwasm'
 import { createBaseConfig } from '../../src/chains/common'
 import { coin } from '../../src/core/coin'
+import {
+  MsgWhitelistSchema,
+  MsgDelistSchema,
+} from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/tx_pb'
+import { Query as MstakingQuery } from '@buf/initia-labs_initia.bufbuild_es/initia/mstaking/v1/query_pb'
+import { anyPack } from '../../src/util/any'
 
 describe('chain configs', () => {
   describe('initia', () => {
@@ -24,6 +31,10 @@ describe('chain configs', () => {
     it('has ophost', () => {
       expect(config.services.ophost).toBeDefined()
       expect(typeof config.msgs.ophost.createBridge).toBe('function')
+    })
+
+    it('wires the generated mstaking query service', () => {
+      expect(config.services.mstaking).toBe(MstakingQuery)
     })
 
     it('all tx-only modules have callable builders', () => {
@@ -67,6 +78,43 @@ describe('chain configs', () => {
       // ethsecp256k1 key (type-only registration)
       const desc = config.registry.getMessage('initia.crypto.v1beta1.ethsecp256k1.PubKey')
       expect(desc).toBeDefined()
+    })
+
+    it('decodes legacy Move whitelist and delist messages without adding builders', () => {
+      const whitelist = create(MsgWhitelistSchema, {
+        authority: 'init1authority',
+        metadataLp: 'lptoken',
+        rewardWeight: '0.5',
+      })
+      const delist = create(MsgDelistSchema, {
+        authority: 'init1authority',
+        metadataLp: 'lptoken',
+      })
+
+      const decodedWhitelist = config.msgs.decode(anyPack(MsgWhitelistSchema, whitelist))
+      expect(decodedWhitelist.typeUrl).toBe('/initia.move.v1.MsgWhitelist')
+      expect(decodedWhitelist.toAmino()).toEqual({
+        type: 'move/MsgWhitelist',
+        value: {
+          authority: 'init1authority',
+          metadata_lp: 'lptoken',
+          reward_weight: '0.5',
+        },
+      })
+      const decodedDelist = config.msgs.decode(anyPack(MsgDelistSchema, delist))
+      expect(decodedDelist.typeUrl).toBe('/initia.move.v1.MsgDelist')
+      expect(decodedDelist.toAmino()).toEqual({
+        type: 'move/MsgDelist',
+        value: {
+          authority: 'init1authority',
+          metadata_lp: 'lptoken',
+        },
+      })
+      expect(config.registry.getMessage('initia.move.v1.MsgWhitelist')).toBeDefined()
+      expect(config.registry.getMessage('initia.move.v1.MsgDelist')).toBeDefined()
+      const moveBuilders = config.msgs.move as unknown as Record<string, unknown>
+      expect(moveBuilders.whitelist).toBeUndefined()
+      expect(moveBuilders.delist).toBeUndefined()
     })
   })
 

--- a/test/unit/client-types.spec.ts
+++ b/test/unit/client-types.spec.ts
@@ -7,7 +7,12 @@ import type {
   BaseClient,
   ClientFor,
   Client,
+  TxOptions,
 } from '../../src/client/types'
+import type { EstimateOptions } from '../../src/client/gas'
+import type { Numeric } from '../../src/types'
+import type { Any } from '@bufbuild/protobuf/wkt'
+import type { QueryDelegatorTotalUnbondingBalanceResponse } from '@buf/initia-labs_initia.bufbuild_es/initia/mstaking/v1/query_pb'
 
 describe('derived client types', () => {
   describe('InitiaClient', () => {
@@ -24,6 +29,17 @@ describe('derived client types', () => {
       expectTypeOf<InitiaClient>().toHaveProperty('distribution')
       expectTypeOf<InitiaClient>().toHaveProperty('ophost')
       expectTypeOf<InitiaClient>().toHaveProperty('gov')
+    })
+
+    it('has generated mstaking total unbonding query but no v1-style wrapper', () => {
+      expectTypeOf<InitiaClient['mstaking']>().toHaveProperty('delegatorTotalUnbondingBalance')
+      expectTypeOf<InitiaClient['mstaking']>().not.toHaveProperty('totalUnbondingBalance')
+
+      type Method = InitiaClient['mstaking']['delegatorTotalUnbondingBalance']
+      expectTypeOf<{ delegatorAddr: string }>().toMatchTypeOf<Parameters<Method>[0]>()
+      expectTypeOf<
+        Awaited<ReturnType<Method>>
+      >().toMatchTypeOf<QueryDelegatorTotalUnbondingBalanceResponse>()
     })
   })
 
@@ -104,5 +120,28 @@ describe('derived client types', () => {
       expectTypeOf<MiniwasmClient>().toMatchTypeOf<Client>()
       expectTypeOf<BaseClient>().toMatchTypeOf<Client>()
     })
+  })
+})
+
+describe('transaction option types', () => {
+  it('exposes TxBody fields on TxOptions', () => {
+    expectTypeOf<TxOptions>().toHaveProperty('timeoutHeight').toEqualTypeOf<Numeric | undefined>()
+    expectTypeOf<TxOptions>().toHaveProperty('extensionOptions').toEqualTypeOf<Any[] | undefined>()
+    expectTypeOf<TxOptions>()
+      .toHaveProperty('nonCriticalExtensionOptions')
+      .toEqualTypeOf<Any[] | undefined>()
+  })
+
+  it('exposes TxBody fields on EstimateOptions', () => {
+    expectTypeOf<EstimateOptions>()
+      .toHaveProperty('timeoutHeight')
+      .toEqualTypeOf<Numeric | undefined>()
+    expectTypeOf<EstimateOptions>()
+      .toHaveProperty('extensionOptions')
+      .toEqualTypeOf<Any[] | undefined>()
+    expectTypeOf<EstimateOptions>()
+      .toHaveProperty('nonCriticalExtensionOptions')
+      .toEqualTypeOf<Any[] | undefined>()
+    expectTypeOf<EstimateOptions>().not.toHaveProperty('signMode')
   })
 })

--- a/test/unit/client/gas.spec.ts
+++ b/test/unit/client/gas.spec.ts
@@ -3,9 +3,13 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
+import { create } from '@bufbuild/protobuf'
+import { AnySchema } from '@bufbuild/protobuf/wkt'
+import { SignMode } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/tx/signing/v1beta1/signing_pb'
 import { DecCoins } from '../../../src/core/coins'
 import { ConnectError, Code } from '@connectrpc/connect'
 import { AccountNotFoundError, SimulationError } from '../../../src/errors'
+import { ExtensionOptionQueuedTx } from '../../../src/tx/extension-options'
 
 // Hoist mock objects so they're available in vi.mock factory
 const { mockAuth, mockTx } = vi.hoisted(() => ({
@@ -152,6 +156,62 @@ describe('estimateGas error narrowing', () => {
     mockTx.simulate.mockResolvedValueOnce({ gasInfo: undefined })
 
     await expect(estimateGas(client, [], 'init1test')).rejects.toThrow(SimulationError)
+  })
+})
+
+describe('estimateGas TxBody options', () => {
+  it('always simulates with SIGN_MODE_DIRECT', async () => {
+    const client = createMockClient()
+    mockedGetAccount.mockResolvedValueOnce({ sequence: 9n, accountNumber: 1n } as any)
+    mockTx.simulate.mockResolvedValueOnce(defaultSimResponse)
+
+    await estimateGas(client, [], 'init1test')
+
+    const simulatedTx = mockTx.simulate.mock.calls.at(-1)?.[0].tx as {
+      authInfo?: {
+        signerInfos?: Array<{
+          modeInfo?: {
+            sum: {
+              case: string
+              value: { mode: number }
+            }
+          }
+        }>
+      }
+    }
+    expect(simulatedTx.authInfo?.signerInfos?.[0].modeInfo?.sum.case).toBe('single')
+    expect(simulatedTx.authInfo?.signerInfos?.[0].modeInfo?.sum.value.mode).toBe(SignMode.DIRECT)
+  })
+
+  it('passes timeout height and extension option arrays into simulation', async () => {
+    const client = createMockClient()
+    const nonCritical = create(AnySchema, {
+      typeUrl: '/example.NonCritical',
+      value: new Uint8Array([4, 5, 6]),
+    })
+    mockedGetAccount.mockResolvedValueOnce({ sequence: 3n, accountNumber: 1n } as any)
+    mockTx.simulate.mockResolvedValueOnce(defaultSimResponse)
+
+    await estimateGas(client, [], 'init1test', {
+      timeoutHeight: 123n,
+      extensionOptions: [ExtensionOptionQueuedTx.packAny()],
+      nonCriticalExtensionOptions: [nonCritical],
+    })
+
+    const simulatedTx = mockTx.simulate.mock.calls.at(-1)?.[0].tx as {
+      body?: {
+        timeoutHeight?: bigint
+        extensionOptions?: Array<{ typeUrl: string }>
+        nonCriticalExtensionOptions?: Array<{ typeUrl: string }>
+      }
+    }
+    expect(simulatedTx.body?.timeoutHeight).toBe(123n)
+    expect(simulatedTx.body?.extensionOptions?.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(simulatedTx.body?.nonCriticalExtensionOptions?.map(o => o.typeUrl)).toEqual([
+      '/example.NonCritical',
+    ])
   })
 })
 

--- a/test/unit/client/mstaking-query-surface.spec.ts
+++ b/test/unit/client/mstaking-query-surface.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { create } from '@bufbuild/protobuf'
+import type { Transport } from '@connectrpc/connect'
+import { CoinSchema } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/base/v1beta1/coin_pb'
+import { QueryDelegatorTotalUnbondingBalanceResponseSchema } from '@buf/initia-labs_initia.bufbuild_es/initia/mstaking/v1/query_pb'
+import { createClientWithConfig } from '../../../src/client/create-client-initia'
+import type { ChainInfo } from '../../../src/provider/types'
+
+describe('mstaking generated query surface', () => {
+  it('proxies delegatorTotalUnbondingBalance through the generated Connect client', async () => {
+    let capturedMethod: string | undefined
+    let capturedInput: unknown
+
+    const transport = {
+      async unary(method, _signal, _timeoutMs, _header, input) {
+        capturedMethod = method.localName
+        capturedInput = input
+        return {
+          stream: false,
+          service: method.parent,
+          method,
+          header: new Headers(),
+          trailer: new Headers(),
+          message: create(QueryDelegatorTotalUnbondingBalanceResponseSchema, {
+            balance: [create(CoinSchema, { denom: 'uinit', amount: '123' })],
+          }),
+        }
+      },
+      async stream() {
+        throw new Error('stream should not be called')
+      },
+    } as Transport
+    const chainInfo: ChainInfo = {
+      chainId: 'initiation-2',
+      chainName: 'Initia',
+      chainType: 'initia',
+      network: 'local',
+    }
+
+    const client = createClientWithConfig(chainInfo, transport)
+    const response = await client.mstaking.delegatorTotalUnbondingBalance({
+      delegatorAddr: 'init1delegator',
+    })
+
+    expect(capturedMethod).toBe('delegatorTotalUnbondingBalance')
+    expect(capturedInput).toMatchObject({ delegatorAddr: 'init1delegator' })
+    expect(response.balance.map(({ denom, amount }) => ({ denom, amount }))).toEqual([
+      { denom: 'uinit', amount: '123' },
+    ])
+  })
+})

--- a/test/unit/client/websocket-session.spec.ts
+++ b/test/unit/client/websocket-session.spec.ts
@@ -16,6 +16,8 @@ import {
 import type { ChainInfo } from '../../../src/provider/types'
 import { getInitiaTestnet, getEvmTestnet } from '../../helpers/test-chains'
 
+const RUN_REAL_WEBSOCKET_TESTS = process.env.TEST_REAL_WEBSOCKET === 'true'
+
 // ============================================================================
 // Mock ChainInfo for mock tests
 // ============================================================================
@@ -416,7 +418,7 @@ describe('WebSocketSession (Mock Tests)', () => {
 // Part 2: Real Network Tests (using testnet)
 // ============================================================================
 
-describe('WebSocketSession (Real Network Tests)', () => {
+describe.skipIf(!RUN_REAL_WEBSOCKET_TESTS)('WebSocketSession (Real Network Tests)', () => {
   let initiaChainInfo: ChainInfo | null = null
   let evmChainInfo: ChainInfo | null = null
 

--- a/test/unit/msgs/to-json.spec.ts
+++ b/test/unit/msgs/to-json.spec.ts
@@ -9,6 +9,11 @@ import { coin } from '../../../src/core/coin'
 import { Message } from '../../../src/msgs/types'
 import { create } from '@bufbuild/protobuf'
 import { AnySchema } from '@bufbuild/protobuf/wkt'
+import {
+  MsgWhitelistSchema,
+  MsgDelistSchema,
+} from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/tx_pb'
+import { anyPack } from '../../../src/util/any'
 
 const baseMsgs = createBaseConfig().build().msgs
 const initiaMsgs = initiaChain.build().msgs
@@ -82,6 +87,36 @@ describe('Message.toJson', () => {
     const msg = Message.fromAny(any)
 
     expect(() => msg.toJson()).toThrow('Cannot convert to JSON on a pre-packed Any')
+  })
+
+  it('should return JSON for legacy Move MsgWhitelist', () => {
+    const value = create(MsgWhitelistSchema, {
+      authority: 'init1authority',
+      metadataLp: 'lptoken',
+      rewardWeight: '0.5',
+    })
+    const json = Message.fromAny(MsgWhitelistSchema, anyPack(MsgWhitelistSchema, value)).toJson()
+
+    expect(json.typeUrl).toBe('/initia.move.v1.MsgWhitelist')
+    expect(json.value).toEqual({
+      authority: 'init1authority',
+      metadataLp: 'lptoken',
+      rewardWeight: '0.5',
+    })
+  })
+
+  it('should return JSON for legacy Move MsgDelist', () => {
+    const value = create(MsgDelistSchema, {
+      authority: 'init1authority',
+      metadataLp: 'lptoken',
+    })
+    const json = Message.fromAny(MsgDelistSchema, anyPack(MsgDelistSchema, value)).toJson()
+
+    expect(json.typeUrl).toBe('/initia.move.v1.MsgDelist')
+    expect(json.value).toEqual({
+      authority: 'init1authority',
+      metadataLp: 'lptoken',
+    })
   })
 
   it('should be usable with map for multiple messages', () => {

--- a/test/unit/tx/amino-coin-serialization.spec.ts
+++ b/test/unit/tx/amino-coin-serialization.spec.ts
@@ -79,6 +79,34 @@ describe('Coin amino serialization', () => {
     expect(aminoJson).toContain('"amount":"20000"')
   })
 
+  it('full amino sign doc includes timeout_height when provided', () => {
+    const stdSignDoc = makeStdSignDoc(
+      [],
+      { amount: [], gas: '200000' },
+      'test-chain',
+      '',
+      0n,
+      0n,
+      42n
+    )
+    const aminoBytes = makeAminoSignBytes(stdSignDoc)
+    const aminoJson = new TextDecoder().decode(aminoBytes)
+
+    expect(JSON.parse(aminoJson)).toMatchObject({ timeout_height: '42' })
+  })
+
+  it('full amino sign doc omits timeout_height when unset or zero', () => {
+    const unset = makeStdSignDoc([], { amount: [], gas: '200000' }, 'test-chain', '', 0n, 0n)
+    const zero = makeStdSignDoc([], { amount: [], gas: '200000' }, 'test-chain', '', 0n, 0n, 0n)
+
+    expect(JSON.parse(new TextDecoder().decode(makeAminoSignBytes(unset)))).not.toHaveProperty(
+      'timeout_height'
+    )
+    expect(JSON.parse(new TextDecoder().decode(makeAminoSignBytes(zero)))).not.toHaveProperty(
+      'timeout_height'
+    )
+  })
+
   it('full amino sign doc WITHOUT buildStdFee should ALSO not contain _amount', () => {
     // This tests the path where Coin instances go directly into stdFee
     // WITHOUT toAmino() conversion — relies on sortObject + JSON.stringify

--- a/test/unit/tx/amino-coverage.spec.ts
+++ b/test/unit/tx/amino-coverage.spec.ts
@@ -52,6 +52,8 @@ import { MsgWithdrawDelegatorRewardSchema } from '@buf/cosmos_cosmos-sdk.bufbuil
 import {
   MsgExecuteSchema as MsgMoveExecuteSchema,
   MsgScriptSchema,
+  MsgWhitelistSchema,
+  MsgDelistSchema,
 } from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/tx_pb'
 
 // Gov v1
@@ -197,6 +199,11 @@ describe('Exception type mappings (proto-amino-conversion-rules.md §1.2)', () =
 
   it('OpInit pattern: ophost/MsgInitiateTokenDeposit', () => {
     expect(getAminoType(MsgInitiateTokenDepositSchema)).toBe('ophost/MsgInitiateTokenDeposit')
+  })
+
+  it('legacy Move whitelist/delist patterns', () => {
+    expect(getAminoType(MsgWhitelistSchema)).toBe('move/MsgWhitelist')
+    expect(getAminoType(MsgDelistSchema)).toBe('move/MsgDelist')
   })
 })
 

--- a/test/unit/tx/amino-value.spec.ts
+++ b/test/unit/tx/amino-value.spec.ts
@@ -13,6 +13,8 @@
 import { describe, it, expect } from 'vitest'
 import { Message } from '../../../src/msgs/types'
 import { create } from '@bufbuild/protobuf'
+import { toAmino } from '../../../src/tx/amino'
+import { anyPack } from '../../../src/util/any'
 
 // ============= Schema imports =============
 
@@ -28,6 +30,8 @@ import { MsgTransferSchema } from '@buf/cosmos_ibc.bufbuild_es/ibc/applications/
 import {
   MsgExecuteSchema as MsgMoveExecuteSchema,
   MsgScriptSchema,
+  MsgWhitelistSchema,
+  MsgDelistSchema,
 } from '@buf/initia-labs_initia.bufbuild_es/initia/move/v1/tx_pb'
 import {
   MsgVoteSchema,
@@ -316,6 +320,52 @@ describe('Move', () => {
     expect(typeof amino.value.code_bytes).toBe('string')
     expect(amino.value.code_bytes).toBe(toBase64(codeBytes))
     expect(amino.value.type_args).toEqual(['0x1::string::String'])
+  })
+
+  it('legacy MsgWhitelist', () => {
+    const value = create(MsgWhitelistSchema, {
+      authority: 'init1authority',
+      metadataLp: 'lptoken',
+      rewardWeight: '0.5',
+    })
+
+    const direct = toAmino(MsgWhitelistSchema, value)
+    const fromAny = Message.fromAny(
+      MsgWhitelistSchema,
+      anyPack(MsgWhitelistSchema, value)
+    ).toAmino()
+
+    expect(direct).toEqual({
+      type: 'move/MsgWhitelist',
+      value: {
+        authority: 'init1authority',
+        metadata_lp: 'lptoken',
+        reward_weight: '0.5',
+      },
+    })
+    expect(fromAny).toEqual(direct)
+    expect(direct.value).not.toHaveProperty('metadataLp')
+    expect(direct.value).not.toHaveProperty('rewardWeight')
+  })
+
+  it('legacy MsgDelist', () => {
+    const value = create(MsgDelistSchema, {
+      authority: 'init1authority',
+      metadataLp: 'lptoken',
+    })
+
+    const direct = toAmino(MsgDelistSchema, value)
+    const fromAny = Message.fromAny(MsgDelistSchema, anyPack(MsgDelistSchema, value)).toAmino()
+
+    expect(direct).toEqual({
+      type: 'move/MsgDelist',
+      value: {
+        authority: 'init1authority',
+        metadata_lp: 'lptoken',
+      },
+    })
+    expect(fromAny).toEqual(direct)
+    expect(direct.value).not.toHaveProperty('metadataLp')
   })
 })
 

--- a/test/unit/tx/extension-options.spec.ts
+++ b/test/unit/tx/extension-options.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { create, fromBinary } from '@bufbuild/protobuf'
+import { AnySchema } from '@bufbuild/protobuf/wkt'
+import { TxBodySchema } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/tx/v1beta1/tx_pb'
+import { ExtensionOptionQueuedTxSchema } from '@buf/initia-labs_initia.bufbuild_es/initia/tx/v1/tx_pb'
+import { Message } from '../../../src/msgs'
+import { UnsignedTx } from '../../../src/tx/unsigned-tx'
+import { encodeTxDirect } from '../../../src/tx/sign'
+import { ExtensionOptionQueuedTx } from '../../../src/tx/extension-options'
+import { ExtensionOptionQueuedTx as TxExportedExtensionOptionQueuedTx } from '../../../src/tx'
+import { ExtensionOptionQueuedTx as RootExportedExtensionOptionQueuedTx } from '../../../src'
+
+describe('ExtensionOptionQueuedTx', () => {
+  it('packs the generated queued tx extension option as a Cosmos Any', () => {
+    const any = ExtensionOptionQueuedTx.packAny()
+
+    expect(any.typeUrl).toBe('/initia.tx.v1.ExtensionOptionQueuedTx')
+    expect(fromBinary(ExtensionOptionQueuedTxSchema, any.value).$typeName).toBe(
+      'initia.tx.v1.ExtensionOptionQueuedTx'
+    )
+  })
+
+  it('is exported from root and tx entry surfaces', () => {
+    expect(ExtensionOptionQueuedTx.TYPE_URL).toBe('/initia.tx.v1.ExtensionOptionQueuedTx')
+    expect(TxExportedExtensionOptionQueuedTx.TYPE_URL).toBe(ExtensionOptionQueuedTx.TYPE_URL)
+    expect(RootExportedExtensionOptionQueuedTx.packAny().typeUrl).toBe(
+      ExtensionOptionQueuedTx.TYPE_URL
+    )
+  })
+})
+
+describe('encodeTxDirect', () => {
+  it('preserves TxBody timeout height and both extension option arrays', () => {
+    const opaqueMsg = Message.fromAny(
+      create(AnySchema, {
+        typeUrl: '/example.Msg',
+        value: new Uint8Array([1, 2, 3]),
+      })
+    )
+    const nonCritical = create(AnySchema, {
+      typeUrl: '/example.NonCritical',
+      value: new Uint8Array([4, 5, 6]),
+    })
+    const tx = new UnsignedTx({
+      msgs: [opaqueMsg],
+      signMode: 'direct',
+      chainId: 'initiation-2',
+      accountNumber: 7n,
+      sequence: 8n,
+      fee: [],
+      gasLimit: 200000n,
+      memo: 'queued',
+      timeoutHeight: 99n,
+      extensionOptions: [ExtensionOptionQueuedTx.packAny()],
+      nonCriticalExtensionOptions: [nonCritical],
+    })
+
+    const { bodyBytes } = encodeTxDirect(tx, new Uint8Array(33).fill(2), 'secp256k1')
+    const body = fromBinary(TxBodySchema, bodyBytes)
+
+    expect(body.timeoutHeight).toBe(99n)
+    expect(body.extensionOptions.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(body.nonCriticalExtensionOptions.map(o => o.typeUrl)).toEqual(['/example.NonCritical'])
+  })
+})

--- a/test/unit/tx/multisig-sign.spec.ts
+++ b/test/unit/tx/multisig-sign.spec.ts
@@ -5,12 +5,16 @@ import { MultisigPublicKey, MultiSignature } from '../../../src/key/multisig'
 import { RawKey } from '../../../src/key/raw-key'
 import { UnsignedTx } from '../../../src/tx/unsigned-tx'
 import { create, fromBinary, toBinary } from '@bufbuild/protobuf'
+import { AnySchema } from '@bufbuild/protobuf/wkt'
 import {
   TxBodySchema,
   AuthInfoSchema,
   FeeSchema,
+  SignDocSchema,
+  TxRawSchema,
 } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/tx/v1beta1/tx_pb'
 import { MultiSignatureSchema } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/crypto/multisig/v1beta1/multisig_pb'
+import { ExtensionOptionQueuedTx } from '../../../src/tx/extension-options'
 
 describe('createSignedTx', () => {
   it('should create TxRaw from multisig components', () => {
@@ -130,9 +134,15 @@ describe('createSignedTx fee preservation', () => {
 describe('multisig e2e signing', () => {
   it('should produce valid signatures that verify against signBytes', async () => {
     // 1. Setup keys
-    const key1 = RawKey.fromHex('0x0000000000000000000000000000000000000000000000000000000000000001')
-    const key2 = RawKey.fromHex('0x0000000000000000000000000000000000000000000000000000000000000002')
-    const key3 = RawKey.fromHex('0x0000000000000000000000000000000000000000000000000000000000000003')
+    const key1 = RawKey.fromHex(
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    )
+    const key2 = RawKey.fromHex(
+      '0x0000000000000000000000000000000000000000000000000000000000000002'
+    )
+    const key3 = RawKey.fromHex(
+      '0x0000000000000000000000000000000000000000000000000000000000000003'
+    )
     const pubKeys = [key1.publicKey, key2.publicKey, key3.publicKey]
     const mpk = new MultisigPublicKey(2, pubKeys)
 
@@ -196,7 +206,10 @@ describe('key.sign(tx) overloads', () => {
   })
 
   it('sign(tx, mpk) auto-detects signer index', async () => {
-    const mpk = new MultisigPublicKey(2, keys.map(k => k.publicKey))
+    const mpk = new MultisigPublicKey(
+      2,
+      keys.map(k => k.publicKey)
+    )
     const tx = new UnsignedTx({
       msgs: [],
       signMode: 'direct',
@@ -216,8 +229,45 @@ describe('key.sign(tx) overloads', () => {
     expect(sig2.index).toBe(2)
   })
 
+  it('getMultisigSignBytes preserves timeout and both extension option arrays', () => {
+    const mpk = new MultisigPublicKey(
+      2,
+      keys.map(k => k.publicKey)
+    )
+    const nonCritical = create(AnySchema, {
+      typeUrl: '/example.NonCritical',
+      value: new Uint8Array([4, 5, 6]),
+    })
+    const tx = new UnsignedTx({
+      msgs: [],
+      signMode: 'direct',
+      chainId: 'test-1',
+      accountNumber: 0n,
+      sequence: 0n,
+      fee: [],
+      gasLimit: 200000n,
+      memo: 'multisig-extension',
+      timeoutHeight: 44n,
+      extensionOptions: [ExtensionOptionQueuedTx.packAny()],
+      nonCriticalExtensionOptions: [nonCritical],
+    })
+
+    const signBytes = tx.getMultisigSignBytes(mpk)
+    const signDoc = fromBinary(SignDocSchema, signBytes)
+    const body = fromBinary(TxBodySchema, signDoc.bodyBytes)
+
+    expect(body.timeoutHeight).toBe(44n)
+    expect(body.extensionOptions.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(body.nonCriticalExtensionOptions.map(o => o.typeUrl)).toEqual(['/example.NonCritical'])
+  })
+
   it('sign(tx, mpk) throws if key not member', async () => {
-    const mpk = new MultisigPublicKey(2, keys.slice(0, 2).map(k => k.publicKey))
+    const mpk = new MultisigPublicKey(
+      2,
+      keys.slice(0, 2).map(k => k.publicKey)
+    )
     const tx = new UnsignedTx({
       msgs: [],
       signMode: 'direct',
@@ -232,7 +282,10 @@ describe('key.sign(tx) overloads', () => {
   })
 
   it('full multisig e2e with new API', async () => {
-    const mpk = new MultisigPublicKey(2, keys.map(k => k.publicKey))
+    const mpk = new MultisigPublicKey(
+      2,
+      keys.map(k => k.publicKey)
+    )
     const tx = new UnsignedTx({
       msgs: [],
       signMode: 'direct',
@@ -252,8 +305,47 @@ describe('key.sign(tx) overloads', () => {
     expect(signedTx.txBytes.length).toBeGreaterThan(0)
   })
 
+  it('assembleMultisig preserves timeout and both extension option arrays in final TxRaw', async () => {
+    const mpk = new MultisigPublicKey(
+      2,
+      keys.map(k => k.publicKey)
+    )
+    const nonCritical = create(AnySchema, {
+      typeUrl: '/example.NonCritical',
+      value: new Uint8Array([4, 5, 6]),
+    })
+    const tx = new UnsignedTx({
+      msgs: [],
+      signMode: 'direct',
+      chainId: 'test-1',
+      accountNumber: 0n,
+      sequence: 0n,
+      fee: [],
+      gasLimit: 200000n,
+      memo: 'e2e-extension',
+      timeoutHeight: 45n,
+      extensionOptions: [ExtensionOptionQueuedTx.packAny()],
+      nonCriticalExtensionOptions: [nonCritical],
+    })
+
+    const sig1 = await keys[0].sign(tx, mpk)
+    const sig2 = await keys[1].sign(tx, mpk)
+    const signedTx = tx.assembleMultisig(mpk, [sig1, sig2])
+    const txRaw = fromBinary(TxRawSchema, signedTx.txBytes)
+    const body = fromBinary(TxBodySchema, txRaw.bodyBytes)
+
+    expect(body.timeoutHeight).toBe(45n)
+    expect(body.extensionOptions.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(body.nonCriticalExtensionOptions.map(o => o.typeUrl)).toEqual(['/example.NonCritical'])
+  })
+
   it('assembleMultisig throws when threshold not met', async () => {
-    const mpk = new MultisigPublicKey(2, keys.map(k => k.publicKey))
+    const mpk = new MultisigPublicKey(
+      2,
+      keys.map(k => k.publicKey)
+    )
     const tx = new UnsignedTx({
       msgs: [],
       signMode: 'direct',
@@ -270,7 +362,10 @@ describe('key.sign(tx) overloads', () => {
   })
 
   it('assembleMultisig throws with zero signatures', () => {
-    const mpk = new MultisigPublicKey(2, keys.map(k => k.publicKey))
+    const mpk = new MultisigPublicKey(
+      2,
+      keys.map(k => k.publicKey)
+    )
     const tx = new UnsignedTx({
       msgs: [],
       signMode: 'direct',
@@ -323,7 +418,15 @@ describe('key.sign(tx) overloads', () => {
   })
 
   it('sign(tx) produces different signatures for different signModes', async () => {
-    const base = { msgs: [], chainId: 'test-1', accountNumber: 0n, sequence: 0n, fee: [], gasLimit: 200000n, memo: '' }
+    const base = {
+      msgs: [],
+      chainId: 'test-1',
+      accountNumber: 0n,
+      sequence: 0n,
+      fee: [],
+      gasLimit: 200000n,
+      memo: '',
+    }
     const directSig = await keys[0].sign(new UnsignedTx({ ...base, signMode: 'direct' }))
     const aminoSig = await keys[0].sign(new UnsignedTx({ ...base, signMode: 'amino' }))
     const eip191Sig = await keys[0].sign(new UnsignedTx({ ...base, signMode: 'eip191' }))

--- a/test/unit/wallet/signing.spec.ts
+++ b/test/unit/wallet/signing.spec.ts
@@ -10,10 +10,11 @@
  * - #109: signMode auto-determination
  * - #110: Incompatible signer + signMode combo errors
  * - #111: createTx() + sign() separate call path
- * - #112: gas.ts estimateGas() stays DIRECT regardless of signMode
  */
 
 import { describe, it, expect } from 'vitest'
+import { create, fromBinary } from '@bufbuild/protobuf'
+import { AnySchema } from '@bufbuild/protobuf/wkt'
 import { buildChainContextFactory } from '../../../src/wallet/chain-context'
 import { RawKey } from '../../../src/key/raw-key'
 import { Message } from '../../../src/msgs/types'
@@ -28,6 +29,11 @@ import type {
 } from '../../../src/signer/types'
 import type { Transport } from '@connectrpc/connect'
 import { base64 } from '@scure/base'
+import {
+  TxBodySchema,
+  TxRawSchema,
+} from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/tx/v1beta1/tx_pb'
+import { ExtensionOptionQueuedTx } from '../../../src/tx/extension-options'
 
 // ============= Fixtures =============
 
@@ -270,6 +276,89 @@ describe('External signer + amino signing (#108)', () => {
 
     expect(signed.txBytes).not.toEqual(signedNoOverride.txBytes)
   })
+
+  it('preserves TxBody extension options and timeout height in final tx bytes', async () => {
+    const signer = createMockAminoSigner()
+    const originalSignAmino = signer.signAmino
+    let capturedSignDoc: AminoSignDoc | undefined
+    signer.signAmino = async (addr, signDoc) => {
+      capturedSignDoc = signDoc
+      return originalSignAmino(addr, signDoc)
+    }
+    const ctx = createChainContext(mockChainInfo, {
+      signer,
+      transport: mockTransport,
+    })
+    const nonCritical = create(AnySchema, {
+      typeUrl: '/example.NonCritical',
+      value: new Uint8Array([4, 5, 6]),
+    })
+    const tx = new UnsignedTx({
+      msgs: [
+        new Message(MsgSendSchema, {
+          fromAddress: testKey.address,
+          toAddress: 'init1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq5qnc04y',
+          amount: [{ denom: 'uinit', amount: '1000000' }],
+        }),
+      ],
+      signMode: 'amino',
+      chainId: 'test-1',
+      accountNumber: 1n,
+      sequence: 0n,
+      fee: [{ denom: 'uinit', amount: '1000' }],
+      gasLimit: 200000n,
+      memo: 'amino-extension',
+      timeoutHeight: 99n,
+      extensionOptions: [ExtensionOptionQueuedTx.packAny()],
+      nonCriticalExtensionOptions: [nonCritical],
+    })
+
+    const signed = await ctx.sign(tx)
+    const txRaw = fromBinary(TxRawSchema, signed.txBytes)
+    const body = fromBinary(TxBodySchema, txRaw.bodyBytes)
+
+    expect(capturedSignDoc?.chain_id).toBe('test-1')
+    expect(capturedSignDoc?.account_number).toBe('1')
+    expect(capturedSignDoc?.sequence).toBe('0')
+    expect(capturedSignDoc?.memo).toBe('amino-extension')
+    expect(capturedSignDoc?.timeout_height).toBe('99')
+    expect(capturedSignDoc?.fee).toEqual({
+      amount: [{ denom: 'uinit', amount: '1000' }],
+      gas: '200000',
+    })
+    expect(capturedSignDoc?.msgs[0].type).toBe('cosmos-sdk/MsgSend')
+    expect(body.timeoutHeight).toBe(99n)
+    expect(body.extensionOptions.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(body.nonCriticalExtensionOptions.map(o => o.typeUrl)).toEqual(['/example.NonCritical'])
+  })
+
+  it('uses signer-modified timeout height in final tx bytes', async () => {
+    const signer = createMockAminoSigner()
+    const originalSignAmino = signer.signAmino
+    signer.signAmino = async (addr, signDoc) => {
+      const response = await originalSignAmino(addr, signDoc)
+      return {
+        ...response,
+        signed: {
+          ...response.signed,
+          timeout_height: '123',
+        },
+      }
+    }
+    const ctx = createChainContext(mockChainInfo, {
+      signer,
+      transport: mockTransport,
+    })
+    const tx = createTestTx('amino')
+
+    const signed = await ctx.sign(tx)
+    const txRaw = fromBinary(TxRawSchema, signed.txBytes)
+    const body = fromBinary(TxBodySchema, txRaw.bodyBytes)
+
+    expect(body.timeoutHeight).toBe(123n)
+  })
 })
 
 // ============= #109: signMode auto-determination =============
@@ -398,51 +487,5 @@ describe('createTx() + sign() separate call path (#111)', () => {
     const signed = await ctx.sign(unsignedTx, { signer: testKey })
     expect(signed.txBytes).toBeInstanceOf(Uint8Array)
     expect(signed.txBytes.length).toBeGreaterThan(0)
-  })
-})
-
-// ============= #112: gas.ts estimateGas() stays DIRECT =============
-
-describe('gas.ts estimateGas() always uses DIRECT (#112)', () => {
-  it('should use SignMode.DIRECT for simulation regardless of message signMode', async () => {
-    const { estimateGas } = await import('../../../src/client/gas')
-
-    // Mock client that captures the simulation request
-    let simulateCalled = false
-    const mockClient = {
-      auth: {
-        account: async () => ({ account: undefined }),
-      },
-      tx: {
-        simulate: async () => {
-          simulateCalled = true
-          return { gasInfo: { gasUsed: 100000n, gasWanted: 150000n } }
-        },
-      },
-    }
-
-    const msg = new Message(MsgSendSchema, {
-      fromAddress: 'init1sender...',
-      toAddress: 'init1receiver...',
-      amount: [{ denom: 'uinit', amount: '1000' }],
-    })
-
-    const result = await estimateGas(mockClient, [msg], 'init1sender...')
-
-    // Verify simulation was called and returned proper result
-    expect(simulateCalled).toBe(true)
-    expect(result.gasLimit).toBeGreaterThan(0n)
-    expect(result.fee).toBeDefined()
-    expect(result.fee.length).toBeGreaterThan(0)
-  })
-
-  it('should not accept signMode in EstimateOptions', async () => {
-    const { estimateGas } = await import('../../../src/client/gas')
-
-    // estimateGas signature: (client, msgs, signer, options?: EstimateOptions)
-    // EstimateOptions only has { multiplier?, gasPrice? } — no signMode
-    // This is verified by the function existing and the first test succeeding
-    // with SignMode.DIRECT hardcoded internally
-    expect(typeof estimateGas).toBe('function')
   })
 })

--- a/test/unit/wallet/tx-extension-options.spec.ts
+++ b/test/unit/wallet/tx-extension-options.spec.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from 'vitest'
+import { create } from '@bufbuild/protobuf'
+import { AnySchema } from '@bufbuild/protobuf/wkt'
+import { fromBinary } from '@bufbuild/protobuf'
+import type { Transport } from '@connectrpc/connect'
+import {
+  TxBodySchema,
+  TxRawSchema,
+} from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/tx/v1beta1/tx_pb'
+import {
+  BroadcastTxResponseSchema,
+  Service as TxService,
+  SimulateResponseSchema,
+} from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/tx/v1beta1/service_pb'
+import {
+  GasInfoSchema,
+  TxResponseSchema,
+} from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/base/abci/v1beta1/abci_pb'
+import {
+  Query as AuthQuery,
+  QueryAccountResponseSchema,
+} from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/auth/v1beta1/query_pb'
+import { BaseAccountSchema } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/auth/v1beta1/auth_pb'
+import { MsgSendSchema } from '@buf/cosmos_cosmos-sdk.bufbuild_es/cosmos/bank/v1beta1/tx_pb'
+import { buildChainContextFactory } from '../../../src/wallet/chain-context'
+import { RawKey } from '../../../src/key/raw-key'
+import { Message } from '../../../src/msgs'
+import { ExtensionOptionQueuedTx } from '../../../src/tx/extension-options'
+import { anyPack } from '../../../src/util/any'
+
+const testKey = RawKey.fromHex('0000000000000000000000000000000000000000000000000000000000000001')
+
+const chainInfo = {
+  chainId: 'test-1',
+  chainName: 'Test Chain',
+  chainType: 'initia' as const,
+  network: 'testnet' as const,
+  bech32Prefix: 'init',
+}
+
+const emptyTransport = {} as Transport
+const createLocalContext = buildChainContextFactory(
+  () => emptyTransport,
+  () => ({}),
+  () => ({}) as never
+)
+
+function sendMsg(): Message<typeof MsgSendSchema> {
+  return new Message(MsgSendSchema, {
+    fromAddress: testKey.address,
+    toAddress: 'init1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq5qnc04y',
+    amount: [{ denom: 'uinit', amount: '1000' }],
+  })
+}
+
+function nonCriticalAny() {
+  return create(AnySchema, {
+    typeUrl: '/example.NonCritical',
+    value: new Uint8Array([4, 5, 6]),
+  })
+}
+
+function decodeBody(txBytes: Uint8Array) {
+  const txRaw = fromBinary(TxRawSchema, txBytes)
+  return fromBinary(TxBodySchema, txRaw.bodyBytes)
+}
+
+describe('ChainContext.createTx extension options', () => {
+  it('stores timeout height and both extension option arrays', async () => {
+    const ctx = createLocalContext(chainInfo, { signer: testKey, transport: emptyTransport })
+    const extensionOptions = [ExtensionOptionQueuedTx.packAny()]
+    const nonCriticalExtensionOptions = [nonCriticalAny()]
+
+    const tx = await ctx.createTx([sendMsg()], {
+      accountNumber: 1n,
+      sequence: 2n,
+      timeoutHeight: 55n,
+      extensionOptions,
+      nonCriticalExtensionOptions,
+    })
+
+    expect(tx.timeoutHeight).toBe(55n)
+    expect(tx.extensionOptions.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(tx.nonCriticalExtensionOptions.map(o => o.typeUrl)).toEqual(['/example.NonCritical'])
+  })
+
+  it('defaults both extension option arrays to empty arrays', async () => {
+    const ctx = createLocalContext(chainInfo, { signer: testKey, transport: emptyTransport })
+
+    const tx = await ctx.createTx([sendMsg()], {
+      accountNumber: 1n,
+      sequence: 2n,
+    })
+
+    expect(tx.extensionOptions).toEqual([])
+    expect(tx.nonCriticalExtensionOptions).toEqual([])
+  })
+
+  it('defensively copies extension option arrays', async () => {
+    const ctx = createLocalContext(chainInfo, { signer: testKey, transport: emptyTransport })
+    const extensionOptions = [ExtensionOptionQueuedTx.packAny()]
+    const nonCriticalExtensionOptions = [nonCriticalAny()]
+
+    const tx = await ctx.createTx([sendMsg()], {
+      accountNumber: 1n,
+      sequence: 2n,
+      extensionOptions,
+      nonCriticalExtensionOptions,
+    })
+    extensionOptions.push(nonCriticalAny())
+    nonCriticalExtensionOptions.push(ExtensionOptionQueuedTx.packAny())
+
+    expect(tx.extensionOptions.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(tx.nonCriticalExtensionOptions.map(o => o.typeUrl)).toEqual(['/example.NonCritical'])
+  })
+})
+
+describe('ChainContext.sign extension options', () => {
+  it('preserves extension options in direct signing body bytes', async () => {
+    const ctx = createLocalContext(chainInfo, { signer: testKey, transport: emptyTransport })
+    const tx = await ctx.createTx([sendMsg()], {
+      accountNumber: 1n,
+      sequence: 2n,
+      fee: [{ denom: 'uinit', amount: '1' }],
+      gasLimit: 200000n,
+      signMode: 'direct',
+      timeoutHeight: 66n,
+      extensionOptions: [ExtensionOptionQueuedTx.packAny()],
+      nonCriticalExtensionOptions: [nonCriticalAny()],
+    })
+
+    const signed = await ctx.sign(tx)
+    const body = decodeBody(signed.txBytes)
+
+    expect(body.timeoutHeight).toBe(66n)
+    expect(body.extensionOptions.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(body.nonCriticalExtensionOptions.map(o => o.typeUrl)).toEqual(['/example.NonCritical'])
+  })
+
+  it('preserves extension options in EIP-191 final body bytes', async () => {
+    let capturedPersonalBytes: Uint8Array | undefined
+    const signer = {
+      algorithm: 'eth_secp256k1' as const,
+      getPublicKey: async () => testKey.publicKey,
+      getAddress: async () => testKey.address,
+      signDirect: async () => {
+        throw new Error('signDirect should not be called')
+      },
+      signPersonal: async (data: Uint8Array) => {
+        capturedPersonalBytes = data
+        return new Uint8Array(64)
+      },
+    }
+    const ctx = createLocalContext(chainInfo, { signer, transport: emptyTransport })
+    const tx = await ctx.createTx([sendMsg()], {
+      accountNumber: 1n,
+      sequence: 2n,
+      fee: [{ denom: 'uinit', amount: '1' }],
+      gasLimit: 200000n,
+      signMode: 'eip191',
+      timeoutHeight: 77n,
+      extensionOptions: [ExtensionOptionQueuedTx.packAny()],
+      nonCriticalExtensionOptions: [nonCriticalAny()],
+    })
+
+    const signed = await ctx.sign(tx)
+    const body = decodeBody(signed.txBytes)
+    const signedJson = JSON.parse(new TextDecoder().decode(capturedPersonalBytes)) as {
+      timeout_height?: string
+    }
+
+    expect(signedJson.timeout_height).toBe('77')
+    expect(body.timeoutHeight).toBe(77n)
+    expect(body.extensionOptions.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(body.nonCriticalExtensionOptions.map(o => o.typeUrl)).toEqual(['/example.NonCritical'])
+  })
+})
+
+describe('ChainContext.signAndBroadcast extension options', () => {
+  it('preserves timeout height and extension options when explicit fee skips auto gas', async () => {
+    let capturedBroadcastTxBytes: Uint8Array | undefined
+    const transport = {
+      async unary(method, _signal, _timeoutMs, _header, input) {
+        if (method.localName === 'account') {
+          return {
+            stream: false,
+            service: method.parent,
+            method,
+            header: new Headers(),
+            trailer: new Headers(),
+            message: create(QueryAccountResponseSchema, {
+              account: anyPack(
+                BaseAccountSchema,
+                create(BaseAccountSchema, {
+                  address: testKey.address,
+                  accountNumber: 1n,
+                  sequence: 2n,
+                })
+              ),
+            }),
+          }
+        }
+        if (method.localName === 'simulate') {
+          throw new Error('simulate should not be called when fee is explicit')
+        }
+        if (method.localName === 'broadcastTx') {
+          capturedBroadcastTxBytes = (input as { txBytes: Uint8Array }).txBytes
+          return {
+            stream: false,
+            service: method.parent,
+            method,
+            header: new Headers(),
+            trailer: new Headers(),
+            message: create(BroadcastTxResponseSchema, {
+              txResponse: create(TxResponseSchema, {
+                txhash: 'ABC123',
+                code: 0,
+                gasUsed: 100000n,
+                rawLog: '',
+              }),
+            }),
+          }
+        }
+        throw new Error(`unexpected method ${method.localName}`)
+      },
+      async stream() {
+        throw new Error('stream should not be called')
+      },
+    } as Transport
+    const createContext = buildChainContextFactory(
+      () => transport,
+      () => ({ auth: AuthQuery, tx: TxService }),
+      () => ({}) as never
+    )
+    const ctx = createContext(chainInfo, { signer: testKey, transport })
+
+    await ctx.signAndBroadcast([sendMsg()], {
+      fee: [{ denom: 'uinit', amount: '1500' }],
+      gasLimit: 200000n,
+      timeoutHeight: 87n,
+      extensionOptions: [ExtensionOptionQueuedTx.packAny()],
+      nonCriticalExtensionOptions: [nonCriticalAny()],
+    })
+
+    expect(capturedBroadcastTxBytes).toBeInstanceOf(Uint8Array)
+    const broadcastBody = decodeBody(capturedBroadcastTxBytes!)
+    expect(broadcastBody.timeoutHeight).toBe(87n)
+    expect(broadcastBody.extensionOptions.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(broadcastBody.nonCriticalExtensionOptions.map(o => o.typeUrl)).toEqual([
+      '/example.NonCritical',
+    ])
+  })
+
+  it('forwards timeout height and extension options into auto gas simulation', async () => {
+    let capturedSimulateInput: unknown
+    let capturedBroadcastTxBytes: Uint8Array | undefined
+    const transport = {
+      async unary(method, _signal, _timeoutMs, _header, input) {
+        if (method.localName === 'account') {
+          return {
+            stream: false,
+            service: method.parent,
+            method,
+            header: new Headers(),
+            trailer: new Headers(),
+            message: create(QueryAccountResponseSchema, {
+              account: anyPack(
+                BaseAccountSchema,
+                create(BaseAccountSchema, {
+                  address: testKey.address,
+                  accountNumber: 1n,
+                  sequence: 2n,
+                })
+              ),
+            }),
+          }
+        }
+        if (method.localName === 'simulate') {
+          capturedSimulateInput = input
+          return {
+            stream: false,
+            service: method.parent,
+            method,
+            header: new Headers(),
+            trailer: new Headers(),
+            message: create(SimulateResponseSchema, {
+              gasInfo: create(GasInfoSchema, { gasUsed: 100000n, gasWanted: 100000n }),
+            }),
+          }
+        }
+        if (method.localName === 'broadcastTx') {
+          capturedBroadcastTxBytes = (input as { txBytes: Uint8Array }).txBytes
+          return {
+            stream: false,
+            service: method.parent,
+            method,
+            header: new Headers(),
+            trailer: new Headers(),
+            message: create(BroadcastTxResponseSchema, {
+              txResponse: create(TxResponseSchema, {
+                txhash: 'ABC123',
+                code: 0,
+                gasUsed: 100000n,
+                rawLog: '',
+              }),
+            }),
+          }
+        }
+        throw new Error(`unexpected method ${method.localName}`)
+      },
+      async stream() {
+        throw new Error('stream should not be called')
+      },
+    } as Transport
+    const createContext = buildChainContextFactory(
+      () => transport,
+      () => ({ auth: AuthQuery, tx: TxService }),
+      () => ({}) as never
+    )
+    const ctx = createContext(chainInfo, { signer: testKey, transport })
+
+    await ctx.signAndBroadcast([sendMsg()], {
+      gasPrice: '0.015uinit',
+      timeoutHeight: 88n,
+      extensionOptions: [ExtensionOptionQueuedTx.packAny()],
+      nonCriticalExtensionOptions: [nonCriticalAny()],
+    })
+
+    const simulatedTx = (capturedSimulateInput as { tx?: { body?: unknown } }).tx
+    const body = simulatedTx?.body as {
+      timeoutHeight?: bigint
+      extensionOptions?: Array<{ typeUrl: string }>
+      nonCriticalExtensionOptions?: Array<{ typeUrl: string }>
+    }
+    expect(body.timeoutHeight).toBe(88n)
+    expect(body.extensionOptions?.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(body.nonCriticalExtensionOptions?.map(o => o.typeUrl)).toEqual(['/example.NonCritical'])
+
+    expect(capturedBroadcastTxBytes).toBeInstanceOf(Uint8Array)
+    const broadcastBody = decodeBody(capturedBroadcastTxBytes!)
+    expect(broadcastBody.timeoutHeight).toBe(88n)
+    expect(broadcastBody.extensionOptions.map(o => o.typeUrl)).toEqual([
+      '/initia.tx.v1.ExtensionOptionQueuedTx',
+    ])
+    expect(broadcastBody.nonCriticalExtensionOptions.map(o => o.typeUrl)).toEqual([
+      '/example.NonCritical',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
  - add v2 support for Initia v1.4.5 compatibility surfaces
  - preserve TxBody timeout height and extension options through signing, multisig, gas simulation, and broadcast paths
  - register legacy Move whitelist/delist messages for decode compatibility without adding v1-style builders
  - lock the generated mstaking total-unbonding query surface
  - stabilize live testnet-dependent websocket/L2/bridge tests so default runs do not fail on infra state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for transaction timeout height and extension options in signing and gas estimation.
  * Added `addDecodeTypes()` method to register custom message types for transaction decoding.
  * Introduced `ExtensionOptionQueuedTx` type for use with transaction extensions.

* **Improvements**
  * Enhanced gas estimation to properly handle transaction body extension options.
  * Improved E2E test reliability with better network error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->